### PR TITLE
Add empty (except for .gitignore) input dir for qlever_e2e example

### DIFF
--- a/examples/qlever_e2e/input/.gitignore
+++ b/examples/qlever_e2e/input/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
This makes it clear that this directory is used and makes sure the
directory isn't created by root