### PR TITLE
Handle tempdirs, change qlever_e2e example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 
 go:
   - "1.11.x"
+  - "1.12.x"
   - "master"
 
 notifications:

--- a/environment.go
+++ b/environment.go
@@ -1,0 +1,141 @@
+package gantry
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/ad-freiburg/gantry/types"
+	"github.com/ghodss/yaml"
+)
+
+// PipelineEnvironment stores additional data for pipelines.
+type PipelineEnvironment struct {
+	Machines    []Machine               `json:"machines"`
+	LogSettings LogSettings             `json:"log"`
+	Environment types.MappingWithEquals `json:"environment"`
+	TempDirPath string                  `json:"tempdir"`
+	tempFiles   []string
+	tempPaths   map[string]string
+}
+
+func NewPipelineEnvironment() *PipelineEnvironment {
+	e := &PipelineEnvironment{}
+	e.tempPaths = make(map[string]string, 0)
+	return e
+}
+
+func (e *PipelineEnvironment) Load(path string) error {
+	if _, err := os.Stat(GantryEnv); path == "" && !os.IsNotExist(err) {
+		path = GantryEnv
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	data, err := ioutil.ReadAll(file)
+	if err != nil {
+		return err
+	}
+	return yaml.Unmarshal(data, e)
+}
+
+func (e *PipelineEnvironment) exportEnvironment(path string) error {
+	data, err := yaml.Marshal(e)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(path, data, 0644)
+}
+
+func (e *PipelineEnvironment) createTemplateParser() *template.Template {
+	fm := template.FuncMap{}
+	for k, v := range e.Environment {
+		fm[k] = func() string { return *v }
+	}
+	fm["TempDir"] = func(args ...interface{}) (string, error) {
+		parts := make([]string, len(args))
+		for i, v := range args {
+			parts[i] = fmt.Sprint(v)
+		}
+		return e.GetOrCreateTempDir(strings.Join(parts, "_"))
+	}
+	t := template.New("template").Funcs(fm)
+	return t
+}
+
+func (e *PipelineEnvironment) ApplyTo(def *PipelineDefinition) error {
+	if err := e.applyVolumes(def); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (e *PipelineEnvironment) applyVolumes(def *PipelineDefinition) error {
+	pipelines, err := def.Pipelines()
+	if err != nil {
+		return err
+	}
+	tp := e.createTemplateParser()
+	for _, s := range pipelines.AllSteps() {
+		for i, volumePath := range s.Volumes {
+			var b bytes.Buffer
+			bw := bufio.NewWriter(&b)
+			t, err := tp.Parse(volumePath)
+			if err != nil {
+				return err
+			}
+			err = t.Execute(bw, nil)
+			if err != nil {
+				return err
+			}
+			bw.Flush()
+			s.Volumes[i] = b.String()
+		}
+	}
+	return nil
+}
+
+func (e *PipelineEnvironment) CleanUp(signal os.Signal) {
+	for _, file := range e.tempFiles {
+		if err := os.Remove(file); err != nil {
+			log.Print(err)
+		}
+	}
+	for _, path := range e.tempPaths {
+		if err := os.RemoveAll(path); err != nil {
+			log.Print(err)
+		}
+	}
+}
+
+func (e *PipelineEnvironment) GetOrCreateTempDir(prefix string) (string, error) {
+	val, ok := e.tempPaths[prefix]
+	if ok {
+		return val, nil
+	}
+	return e.TempDir(prefix)
+}
+
+func (e *PipelineEnvironment) TempDir(prefix string) (string, error) {
+	path, err := ioutil.TempDir(e.TempDirPath, prefix)
+	if err == nil {
+		e.tempPaths[prefix] = path
+	}
+	return path, os.Chmod(path, 0777)
+}
+
+func (e *PipelineEnvironment) TempFile(pattern string) (*os.File, error) {
+	file, err := ioutil.TempFile(e.TempDirPath, pattern)
+	if err == nil {
+		e.tempFiles = append(e.tempFiles, file.Name())
+	}
+	return file, err
+}

--- a/environment.go
+++ b/environment.go
@@ -31,7 +31,7 @@ func NewPipelineEnvironment() *PipelineEnvironment {
 }
 
 func (e *PipelineEnvironment) Load(path string) error {
-	if _, err := os.Stat(GantryEnv); path == "" && !os.IsNotExist(err) {
+	if _, err := os.Stat(GantryEnv); path == "" && os.IsExist(err) {
 		path = GantryEnv
 	}
 	file, err := os.Open(path)

--- a/examples/qlever_e2e/gantry.def.yml
+++ b/examples/qlever_e2e/gantry.def.yml
@@ -4,7 +4,7 @@ services:
   qlever:
     image: niklas88/qlever
     volumes:
-      - ./index:/index
+      - "{{TempDir \"index\"}}:/index"
     environment:
       - INDEX_PREFIX=scientists-index
     depends_on:
@@ -15,7 +15,7 @@ steps:
   download_input:
     image: busybox
     volumes:
-      - ./input:/input
+      - "{{TempDir \"input\"}}:/input"
     command:
       "wget -P /input/ http://qlever.cs.uni-freiburg.de/data/scientist-collection.zip"
 
@@ -24,7 +24,7 @@ steps:
       - download_input
     image: busybox
     volumes:
-      - ./input:/input
+      - "{{TempDir \"input\"}}:/input"
     command:
       "unzip -d /input /input/scientist-collection.zip"
 
@@ -33,8 +33,8 @@ steps:
       - unzip_input
     image: niklas88/qlever
     volumes:
-      - ./input/scientist-collection:/input:ro
-      - ./index:/index
+      - "{{TempDir \"input\"}}/scientist-collection:/input:ro"
+      - "{{TempDir \"index\"}}:/index"
     entrypoint: "IndexBuilderMain"
     command: "-l -i /index/scientists-index -f /input/scientists.nt -w /input/scientists.wordsfile.tsv -d /input/scientists.docsfile.tsv"
 
@@ -49,19 +49,5 @@ steps:
     after:
       - wait_for_qlever
     image: niklas88/qlever
-    volumes:
-      - ./tests:/tests
     entrypoint: python3
     command: "/app/e2e/queryit.py /app/e2e/scientists_queries.yaml http://qlever:7001"
-
-  clean:
-    after:
-      - run_queries
-    volumes:
-      - ./input:/input
-      - ./index:/index
-    image: busybox
-    entrypoint: "sh -c"
-    # "'" so we pass the whole command as one argument to sh -c
-    command: "'rm -rf /input/* /index/*'"
-

--- a/examples/qlever_e2e/index/.gitignore
+++ b/examples/qlever_e2e/index/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/examples/qlever_e2e/input/.gitignore
+++ b/examples/qlever_e2e/input/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/log.go
+++ b/log.go
@@ -91,6 +91,9 @@ func init() {
 	friendlyColors = NewColorStore([]int{AnsiForegroundColorCyan, AnsiForegroundColorYellow, AnsiForegroundColorMagenta, AnsiForegroundColorBlue, AnsiForegroundColorLightCyan, AnsiForegroundColorLightYellow, AnsiForegroundColorLightMagenta, AnsiForegroundColorLightBlue})
 }
 
+type LogSettings struct {
+}
+
 // ApplyAnsiStyle applies ansi integer styles to text
 func ApplyAnsiStyle(text string, style ...int) string {
 	return fmt.Sprintf(GenericStringFormat, BuildAnsiStyle(style...), text)

--- a/pipeline_internal_test.go
+++ b/pipeline_internal_test.go
@@ -1,0 +1,32 @@
+package gantry
+
+import (
+	"testing"
+
+	"github.com/ad-freiburg/gantry/types"
+)
+
+func TestPipelineDefinitionPipelines(t *testing.T) {
+	cases := []struct {
+		definition PipelineDefinition
+		err        string
+		result     Pipelines
+	}{
+		{PipelineDefinition{ignoredSteps: types.StringSet{"a": true}, Steps: StepList{"b": Step{Service: Service{Name: "b"}, After: map[string]bool{"a": true}}}, Services: ServiceList{"c": Step{Service: Service{Name: "c", DependsOn: map[string]bool{"a": true}}}}}, "", [][]Step{{{}}, {{}}}},
+	}
+
+	for _, c := range cases {
+		r, err := c.definition.Pipelines()
+		if (err == nil && c.err != "") || (err != nil && c.err == "") {
+			t.Errorf("Incorrect error for '%v', got: '%s', wanted '%s'", c.definition, err, c.err)
+		}
+		if err != nil {
+			continue
+		}
+		for i, ri := range *r {
+			if len(ri) != len(c.result[i]) {
+				t.Errorf("Incorrect length for '%v'@'%d', got: '%d', wanted: '%d'", c.definition, i, len(ri), len(c.result[i]))
+			}
+		}
+	}
+}

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -1,12 +1,10 @@
 package gantry_test
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/ad-freiburg/gantry"
-	"github.com/ad-freiburg/gantry/types"
 )
 
 func TestPipelinesAllSteps(t *testing.T) {
@@ -59,7 +57,6 @@ func TestPipelineDefinitionPipelines(t *testing.T) {
 		{gantry.PipelineDefinition{Steps: gantry.StepList{"a": gantry.Step{}}}, "", gantry.Pipelines{[]gantry.Step{{}}}},
 		{gantry.PipelineDefinition{Services: gantry.ServiceList{"a": gantry.Step{}}}, "", gantry.Pipelines{[]gantry.Step{{}}}},
 		{gantry.PipelineDefinition{Steps: gantry.StepList{"a": gantry.Step{}}, Services: gantry.ServiceList{"a": gantry.Step{}}}, "Redeclaration of step 'a'", gantry.Pipelines{}},
-		{gantry.PipelineDefinition{IgnoredSteps: types.StringSet{"a": true}, Steps: gantry.StepList{"b": gantry.Step{Service: gantry.Service{Name: "b"}, After: map[string]bool{"a": true}}}, Services: gantry.ServiceList{"c": gantry.Step{Service: gantry.Service{Name: "c", DependsOn: map[string]bool{"a": true}}}}}, "", [][]gantry.Step{{{}}, {{}}}},
 	}
 
 	for _, c := range cases {
@@ -70,7 +67,6 @@ func TestPipelineDefinitionPipelines(t *testing.T) {
 		if err != nil {
 			continue
 		}
-		fmt.Printf("%#v\n", *r)
 		for i, ri := range *r {
 			if len(ri) != len(c.result[i]) {
 				t.Errorf("Incorrect length for '%v'@'%d', got: '%d', wanted: '%d'", c.definition, i, len(ri), len(c.result[i]))


### PR DESCRIPTION
Using the [tempalte](https://golang.org/pkg/text/template/) package multiple temporary directories can be used.
Gantry [tries](https://github.com/ad-freiburg/gantry/compare/master...lehmann-4178656ch:tempdirs?expand=1#diff-ff7686b39bf90dc2520886fb874371a4R67) to clean these up even if [killed](https://github.com/ad-freiburg/gantry/compare/master...lehmann-4178656ch:tempdirs?expand=1#diff-ff7686b39bf90dc2520886fb874371a4R114).

As the qlever end-to-end tests do not require persistent data this example is changed to use the new functionality.