### PR TITLE
Restart and substitutions

### DIFF
--- a/cmd/dot.go
+++ b/cmd/dot.go
@@ -52,4 +52,5 @@ var dotCmd = &cobra.Command{
 		w.Flush()
 		return nil
 	},
+	PersistentPostRun: func(cmd *cobra.Command, args []string) {},
 }

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -12,8 +12,6 @@ var downCmd = &cobra.Command{
 	Use:   "down",
 	Short: "Stop and remove containers, and networks created by `up`",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// This is a docker-compose only command, do not try to clean up TempDirs
-		pipeline.Environment.TempDirNoAutoClean = true
 		if err := killCmd.RunE(cmd, args); err != nil {
 			return err
 		}
@@ -22,4 +20,5 @@ var downCmd = &cobra.Command{
 		}
 		return pipeline.RemoveNetwork()
 	},
+	PersistentPostRun: func(cmd *cobra.Command, args []string) {},
 }

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -12,10 +12,14 @@ var downCmd = &cobra.Command{
 	Use:   "down",
 	Short: "Stop and remove containers, and networks created by `up`",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := killCmd.RunE(cmd, args)
-		if err != nil {
+		// This is a docker-compose only command, do not try to clean up TempDirs
+		pipeline.Environment.TempDirNoAutoClean = true
+		if err := killCmd.RunE(cmd, args); err != nil {
 			return err
 		}
-		return rmCmd.RunE(cmd, args)
+		if err := rmCmd.RunE(cmd, args); err != nil {
+			return err
+		}
+		return pipeline.RemoveNetwork()
 	},
 }

--- a/cmd/steps.go
+++ b/cmd/steps.go
@@ -23,4 +23,5 @@ var stepsCmd = &cobra.Command{
 		}
 		return nil
 	},
+	PersistentPostRun: func(cmd *cobra.Command, args []string) {},
 }

--- a/examples/diamond_ignore_failure/gantry.env.yml
+++ b/examples/diamond_ignore_failure/gantry.env.yml
@@ -2,5 +2,5 @@ version: "0"
 
 steps:
   b:
-    ignore-failure: true
+    ignore_failure: true
 

--- a/examples/qlever_e2e/gantry.env.yml
+++ b/examples/qlever_e2e/gantry.env.yml
@@ -1,4 +1,4 @@
-environment:
+substitutions:
   QLEVER_INDEX: index
 
 services:

--- a/meta.go
+++ b/meta.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -82,7 +81,6 @@ func (d *ServiceKeepAlive) UnmarshalJSON(b []byte) error {
 	case "replace":
 		*d = KeepAliveReplace
 	}
-	log.Printf("%#v %#v", string(b), *d)
 	return nil
 }
 

--- a/meta.go
+++ b/meta.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -43,8 +44,8 @@ func (r *ServiceMetaList) UnmarshalJSON(data []byte) error {
 
 type ServiceMeta struct {
 	Ignore        bool             `json:"ignore"`
-	IgnoreFailure bool             `json:"ignore-failure"`
-	KeepAlive     ServiceKeepAlive `json:"keep-alive"`
+	IgnoreFailure bool             `json:"ignore_failure"`
+	KeepAlive     ServiceKeepAlive `json:"keep_alive"`
 	Stdout        ServiceLog       `json:"stdout"`
 	Stderr        ServiceLog       `json:"stderr"`
 }
@@ -81,6 +82,7 @@ func (d *ServiceKeepAlive) UnmarshalJSON(b []byte) error {
 	case "replace":
 		*d = KeepAliveReplace
 	}
+	log.Printf("%#v %#v", string(b), *d)
 	return nil
 }
 

--- a/meta_test.go
+++ b/meta_test.go
@@ -86,8 +86,8 @@ func TestMetaServiceMeta(t *testing.T) {
 	}{
 		{`{}`, gantry.ServiceMeta{Ignore: false, IgnoreFailure: false, KeepAlive: 0, Stdout: gantry.ServiceLog{Handler: 0, Path: ""}, Stderr: gantry.ServiceLog{Handler: 0, Path: ""}}},
 		{`{"ignore": true}`, gantry.ServiceMeta{Ignore: true, IgnoreFailure: false, KeepAlive: 0, Stdout: gantry.ServiceLog{Handler: 0, Path: ""}, Stderr: gantry.ServiceLog{Handler: 0, Path: ""}}},
-		{`{"ignore-failure": true}`, gantry.ServiceMeta{Ignore: false, IgnoreFailure: true, KeepAlive: 0, Stdout: gantry.ServiceLog{Handler: 0, Path: ""}, Stderr: gantry.ServiceLog{Handler: 0, Path: ""}}},
-		{`{"keep-alive": "replace"}`, gantry.ServiceMeta{Ignore: false, IgnoreFailure: false, KeepAlive: gantry.KeepAliveReplace, Stdout: gantry.ServiceLog{Handler: 0, Path: ""}, Stderr: gantry.ServiceLog{Handler: 0, Path: ""}}},
+		{`{"ignore_failure": true}`, gantry.ServiceMeta{Ignore: false, IgnoreFailure: true, KeepAlive: 0, Stdout: gantry.ServiceLog{Handler: 0, Path: ""}, Stderr: gantry.ServiceLog{Handler: 0, Path: ""}}},
+		{`{"keep_alive": "replace"}`, gantry.ServiceMeta{Ignore: false, IgnoreFailure: false, KeepAlive: gantry.KeepAliveReplace, Stdout: gantry.ServiceLog{Handler: 0, Path: ""}, Stderr: gantry.ServiceLog{Handler: 0, Path: ""}}},
 		{`{"stdout": {"handler": "discard"}}`, gantry.ServiceMeta{Ignore: false, IgnoreFailure: false, KeepAlive: 0, Stdout: gantry.ServiceLog{Handler: gantry.LogHandlerDiscard, Path: ""}, Stderr: gantry.ServiceLog{Handler: 0, Path: ""}}},
 		{`{"stderr": {"handler": "discard"}}`, gantry.ServiceMeta{Ignore: false, IgnoreFailure: false, KeepAlive: 0, Stdout: gantry.ServiceLog{Handler: 0, Path: ""}, Stderr: gantry.ServiceLog{Handler: gantry.LogHandlerDiscard, Path: ""}}},
 	}
@@ -130,6 +130,8 @@ func TestMetaServiceMetaList(t *testing.T) {
 		{`{"a": {}}`, gantry.ServiceMetaList{"a": gantry.ServiceMeta{}}},
 		{`{"a": {}, "b": {}}`, gantry.ServiceMetaList{"a": gantry.ServiceMeta{}, "b": gantry.ServiceMeta{}}},
 		{`{"a": {}, "a": {}}`, gantry.ServiceMetaList{"a": gantry.ServiceMeta{}}},
+		{`{"a": {}, "b": {"keep_alive": "yes"}}`, gantry.ServiceMetaList{"a": gantry.ServiceMeta{}, "b": gantry.ServiceMeta{KeepAlive: gantry.KeepAliveYes}}},
+		{`{"a": {}, "b": {"keep_alive": "no"}}`, gantry.ServiceMetaList{"a": gantry.ServiceMeta{}, "b": gantry.ServiceMeta{KeepAlive: gantry.KeepAliveNo}}},
 	}
 
 	for _, c := range cases {
@@ -139,6 +141,11 @@ func TestMetaServiceMetaList(t *testing.T) {
 		}
 		if len(r) != len(c.result) {
 			t.Errorf("Incorrect number of entries in ServiceMetaList for '%s', got: '%d', wanted: '%d'", c.input, len(r), len(c.result))
+		}
+		for key, meta := range r {
+			if meta.KeepAlive != c.result[key].KeepAlive {
+				t.Errorf("Incorrect KeepAlive for '%s', got: '%d', wanted: '%d'", c.input, meta.KeepAlive, c.result[key].KeepAlive)
+			}
 		}
 	}
 }

--- a/pipeline.go
+++ b/pipeline.go
@@ -418,6 +418,7 @@ func (p Pipeline) KillContainers() error {
 	for _, pipeline := range *pipelines {
 		for _, step := range pipeline {
 			NewContainerKiller(step)()
+			NewOldContainerRemover(step)()
 		}
 	}
 	return nil
@@ -435,6 +436,7 @@ func (p Pipeline) PreRunKillContainers() error {
 				continue
 			}
 			NewContainerKiller(step)()
+			NewOldContainerRemover(step)()
 		}
 	}
 	return nil
@@ -494,6 +496,7 @@ func (p Pipeline) RemoveTempDirData() error {
 		i += 1
 	}
 	NewContainerKiller(step)()
+	NewOldContainerRemover(step)()
 	pipelineLogger.Printf("- Starting: %s", step.ColoredName())
 	duration, err := executeF(NewContainerRunner(step, p.NetworkName))
 	if err != nil {
@@ -532,6 +535,7 @@ func runParallelStep(step Step, pipeline Pipeline, durations *sync.Map, wg *sync
 	// Kill old container if KeepAlive_Replace
 	pipelineLogger.Printf("- Killing: %s", step.ColoredContainerName())
 	NewContainerKiller(step)()
+	NewOldContainerRemover(step)()
 	pipelineLogger.Printf("- Starting: %s", step.ColoredContainerName())
 	duration, err := executeF(NewContainerRunner(step, pipeline.NetworkName))
 	if err != nil {

--- a/pipeline.go
+++ b/pipeline.go
@@ -65,7 +65,7 @@ func (p *Pipeline) CleanUp(signal os.Signal) {
 		for _, step := range pipeline {
 			if step.Meta.KeepAlive == KeepAliveNo {
 				NewContainerKiller(step)()
-				NewOldContainerRemover(step)()
+				NewContainerRemover(step)()
 			} else {
 				if Verbose {
 					log.Printf("Keeping network as '%s' can be still alive", step.ColoredName())
@@ -418,7 +418,7 @@ func (p Pipeline) KillContainers() error {
 	for _, pipeline := range *pipelines {
 		for _, step := range pipeline {
 			NewContainerKiller(step)()
-			NewOldContainerRemover(step)()
+			NewContainerRemover(step)()
 		}
 	}
 	return nil
@@ -436,7 +436,7 @@ func (p Pipeline) PreRunKillContainers() error {
 				continue
 			}
 			NewContainerKiller(step)()
-			NewOldContainerRemover(step)()
+			NewContainerRemover(step)()
 		}
 	}
 	return nil
@@ -450,7 +450,7 @@ func (p Pipeline) RemoveContainers() error {
 	}
 	for _, pipeline := range *pipelines {
 		for _, step := range pipeline {
-			NewOldContainerRemover(step)()
+			NewContainerRemover(step)()
 		}
 	}
 	return nil
@@ -496,14 +496,14 @@ func (p Pipeline) RemoveTempDirData() error {
 		i += 1
 	}
 	NewContainerKiller(step)()
-	NewOldContainerRemover(step)()
+	NewContainerRemover(step)()
 	pipelineLogger.Printf("- Starting: %s", step.ColoredName())
 	duration, err := executeF(NewContainerRunner(step, p.NetworkName))
 	if err != nil {
 		pipelineLogger.Printf("  %s: %s", step.ColoredName(), err)
 	}
 	pipelineLogger.Printf("- Finished %s after %s", step.ColoredName(), duration)
-	NewOldContainerRemover(step)()
+	NewContainerRemover(step)()
 	return err
 }
 
@@ -535,7 +535,7 @@ func runParallelStep(step Step, pipeline Pipeline, durations *sync.Map, wg *sync
 	// Kill old container if KeepAlive_Replace
 	pipelineLogger.Printf("- Killing: %s", step.ColoredContainerName())
 	NewContainerKiller(step)()
-	NewOldContainerRemover(step)()
+	NewContainerRemover(step)()
 	pipelineLogger.Printf("- Starting: %s", step.ColoredContainerName())
 	duration, err := executeF(NewContainerRunner(step, pipeline.NetworkName))
 	if err != nil {

--- a/pipeline.go
+++ b/pipeline.go
@@ -83,7 +83,6 @@ func (p *Pipeline) CleanUp(signal os.Signal) {
 	}
 	// Remove network if not needed anymore
 	if !keepNetworkAlive {
-		log.Print("Removing network")
 		p.RemoveNetwork()
 	}
 	p.Environment.CleanUp(signal)

--- a/pipeline.go
+++ b/pipeline.go
@@ -67,6 +67,9 @@ func (p *Pipeline) CleanUp(signal os.Signal) {
 				NewContainerKiller(step)()
 				NewOldContainerRemover(step)()
 			} else {
+				if Verbose {
+					log.Printf("Keeping network as '%s' can be still alive", step.ColoredName())
+				}
 				keepNetworkAlive = true
 			}
 			step.Meta.Close()
@@ -80,6 +83,7 @@ func (p *Pipeline) CleanUp(signal os.Signal) {
 	}
 	// Remove network if not needed anymore
 	if !keepNetworkAlive {
+		log.Print("Removing network")
 		p.RemoveNetwork()
 	}
 	p.Environment.CleanUp(signal)
@@ -221,6 +225,7 @@ func NewPipelineDefinition(path string, env *PipelineEnvironment) (*PipelineDefi
 		s, ok := d.Steps[name]
 		if ok {
 			s.Meta = meta
+			s.Meta.KeepAlive = KeepAliveNo
 			d.Steps[name] = s
 		} else if !meta.Ignore {
 			log.Printf("Metadata: unknown step '%s'", name)

--- a/runner.go
+++ b/runner.go
@@ -191,7 +191,7 @@ func NewImageExistenceChecker(step Step) func() error {
 	}
 }
 
-func NewOldContainerRemover(step Step) func() error {
+func NewContainerRemover(step Step) func() error {
 	return func() error {
 		if Verbose {
 			log.Printf("Remove container '%s'", step.ContainerName())

--- a/step.go
+++ b/step.go
@@ -20,6 +20,7 @@ type Service struct {
 	Volumes     []string                  `json:"volumes"`
 	Environment types.MappingWithEquals   `json:"environment"`
 	DependsOn   types.StringSet           `json:"depends_on"`
+	Restart     string                    `json:"restart"`
 	Name        string
 	Meta        ServiceMeta
 	color       int
@@ -121,6 +122,10 @@ func (s Step) RunCommand(network string) []string {
 		args = append(args, "-d")
 	} else {
 		args = append(args, "--rm")
+	}
+	if s.Restart != "" {
+		args = append(args, "--restart")
+		args = append(args, s.Restart)
 	}
 	for _, port := range s.Ports {
 		args = append(args, "-p", port)


### PR DESCRIPTION
* Adds `restart` to `gantry.def.yml` for deploying services - currently without sanity checks. The provided value will be handed over to `docker`/`wharfer`

* Rename `environment` to `substitutions` in `gantry.env.yml` to emphasis that these are not automatically added services and steps. Addition of values is only done in `gantry.def.yml`/`docker-compose.yml`

* Change `keep-alive` to `keep_alive` and `ignore-failure` to `ignore_failure` to be consistent with naming in `docker-compose.yml`

* Change `down`,`dot` and `steps` commands to ignore normal CleanUp procedures as these are
  * `down`: explicitly performed
  * `dot`, `steps`: not needed as no containers are executed