### PR TITLE
Rework PreRun kill and rm, only delete TempDirs if used

### DIFF
--- a/cmd/kill.go
+++ b/cmd/kill.go
@@ -12,6 +12,6 @@ var killCmd = &cobra.Command{
 	Use:   "kill",
 	Short: "Force stop containers",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return pipeline.KillContainers()
+		return pipeline.KillContainers(false)
 	},
 }

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -12,6 +12,6 @@ var rmCmd = &cobra.Command{
 	Use:   "rm",
 	Short: "Removes stopped containers",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return pipeline.RemoveContainers()
+		return pipeline.RemoveContainers(false)
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -63,12 +63,10 @@ var rootCmd = &cobra.Command{
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := pipeline.PreRunKillContainers()
-		if err != nil {
+		if err := pipeline.KillContainers(true); err != nil {
 			return err
 		}
-		err = rmCmd.RunE(cmd, args)
-		if err != nil {
+		if err := pipeline.RemoveContainers(true); err != nil {
 			return err
 		}
 		return upCmd.RunE(cmd, args)


### PR DESCRIPTION
* fixes #12
  Remove `PreRunKillContainers` and use the same logic for handling `keep_alive: "replace"` in `RemoveContainers` and `KillContainers`
* Add some logic to only start the `TempDirCleanUp` container if needed. 