### PR TITLE
Allow to set project name in gantry.env.yml

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,6 +47,9 @@ var rootCmd = &cobra.Command{
 		if err = pipeline.Check(); err != nil {
 			log.Fatal(err)
 		}
+		if pipeline.Environment.ProjectName != "" {
+			gantry.ProjectName = pipeline.Environment.ProjectName
+		}
 		if gantry.ProjectName == "" {
 			// If ProjectName was not set, try to calculate it
 			if gantry.Verbose {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,7 +47,7 @@ var rootCmd = &cobra.Command{
 		if err = pipeline.Check(); err != nil {
 			log.Fatal(err)
 		}
-		if pipeline.Environment.ProjectName != "" {
+		if gantry.ProjectName == "" && pipeline.Environment.ProjectName != "" {
 			gantry.ProjectName = pipeline.Environment.ProjectName
 		}
 		if gantry.ProjectName == "" {

--- a/environment.go
+++ b/environment.go
@@ -26,6 +26,7 @@ type PipelineEnvironment struct {
 	TempDirNoAutoClean bool                    `json:"tempdir_no_autoclean"`
 	Services           ServiceMetaList         `json:"services"`
 	Steps              ServiceMetaList         `json:"steps"`
+	ProjectName        string                  `json:"project_name"`
 	tempFiles          []string
 	tempPaths          map[string]string
 }

--- a/examples/diamond_ignore_failure/gantry.env.yml
+++ b/examples/diamond_ignore_failure/gantry.env.yml
@@ -1,5 +1,7 @@
 version: "0"
 
+project_name: Ignore Failure
+
 steps:
   b:
     ignore_failure: true


### PR DESCRIPTION
This allows to set a specific project name in `gantry.env.yml`.  `--project-name` can still override it but declaring it in the `gantry.env.yml` disables the automatic name generation if it is not empty.

When merged this allows multiple `gantry.env.yml` in the same directory to have predictable (static) and different project names without the need to specify them on each `gantry` call explicitly.