### PR TITLE
Add tests enabled by #18

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,7 +80,9 @@ var rootCmd = &cobra.Command{
 		return upCmd.RunE(cmd, args)
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
-		pipeline.CleanUp(syscall.Signal(0))
+		if err := pipeline.CleanUp(syscall.Signal(0)); err != nil {
+			log.Fatal(err)
+		}
 	},
 	Version:                gantry.Version,
 	BashCompletionFunction: bashCompletionFunc,
@@ -132,10 +134,14 @@ func signalHandler() {
 	for s := range c {
 		switch s {
 		case syscall.SIGINT:
-			pipeline.CleanUp(s)
+			if err := pipeline.CleanUp(s); err != nil {
+				log.Fatal(err)
+			}
 			os.Exit(1)
 		case syscall.SIGKILL:
-			pipeline.CleanUp(s)
+			if err := pipeline.CleanUp(s); err != nil {
+				log.Fatal(err)
+			}
 			os.Exit(1)
 		case syscall.SIGCHLD:
 		default:

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -12,12 +12,10 @@ var upCmd = &cobra.Command{
 	Use:   "up [flags] [Service/Step...]",
 	Short: "Builds, (re)creates, and starts containers",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := pipeline.PullImages(false)
-		if err != nil {
+		if err := pipeline.PullImages(false); err != nil {
 			return err
 		}
-		err = buildCmd.RunE(cmd, args)
-		if err != nil {
+		if err := buildCmd.RunE(cmd, args); err != nil {
 			return err
 		}
 		return startCmd.RunE(cmd, args)

--- a/environment.go
+++ b/environment.go
@@ -249,7 +249,7 @@ func (e *PipelineEnvironment) ApplyTo(rawFile []byte) ([]byte, error) {
 }
 
 // CleanUp tries to remove all managed temporary files and directories.
-func (e *PipelineEnvironment) CleanUp(signal os.Signal) {
+func (e *PipelineEnvironment) CleanUp(signal os.Signal) error {
 	for _, file := range e.tempFiles {
 		if err := os.Remove(file); err != nil {
 			log.Print(err)
@@ -260,6 +260,7 @@ func (e *PipelineEnvironment) CleanUp(signal os.Signal) {
 			log.Print(err)
 		}
 	}
+	return nil
 }
 
 func (e *PipelineEnvironment) getOrCreateTempDir(prefix string) (string, error) {

--- a/examples_internal_test.go
+++ b/examples_internal_test.go
@@ -1,0 +1,298 @@
+package gantry
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/ad-freiburg/gantry/types"
+)
+
+func TestExamples(t *testing.T) {
+	examples := []struct {
+		dir   string
+		def   string
+		env   string
+		cases []struct {
+			key    string
+			runner bool
+			calls  int
+			called int
+		}
+	}{
+		{
+			"diamond",
+			"gantry.def.yml",
+			"",
+			[]struct {
+				key    string
+				runner bool
+				calls  int
+				called int
+			}{
+				{"NetworkCreator(test)", true, 1, 1},
+				{"ImageExistenceChecker(a)", true, 1, 1},
+				{"ImageExistenceChecker(b)", true, 1, 1},
+				{"ImageExistenceChecker(c)", true, 1, 1},
+				{"ImageExistenceChecker(d)", true, 1, 1},
+				{"ContainerKiller(a)", true, 3, 3},
+				{"ContainerKiller(b)", true, 3, 3},
+				{"ContainerKiller(c)", true, 3, 3},
+				{"ContainerKiller(d)", true, 3, 3},
+				{"ContainerKiller(TempDirCleanUp)", true, 0, 0},
+				{"ContainerRemover(a)", true, 4, 4},
+				{"ContainerRemover(b)", true, 4, 4},
+				{"ContainerRemover(c)", true, 4, 4},
+				{"ContainerRemover(d)", true, 4, 4},
+				{"ContainerRemover(TempDirCleanUp)", true, 0, 0},
+				{"ContainerRunner(a,test)", true, 1, 1},
+				{"ContainerRunner(b,test)", true, 1, 1},
+				{"ContainerRunner(c,test)", true, 1, 1},
+				{"ContainerRunner(d,test)", true, 1, 1},
+				{"ContainerRunner(TempDirCleanUp,test)", true, 0, 0},
+			},
+		},
+		{
+			"diamond_ignore_failure",
+			"gantry.def.yml",
+			"gantry.env.yml",
+			[]struct {
+				key    string
+				runner bool
+				calls  int
+				called int
+			}{
+				{"NetworkCreator(test)", true, 1, 1},
+				{"ImageExistenceChecker(a)", true, 1, 1},
+				{"ImageExistenceChecker(b)", true, 1, 1},
+				{"ImageExistenceChecker(c)", true, 1, 1},
+				{"ImageExistenceChecker(d)", true, 1, 1},
+				{"ContainerKiller(a)", true, 3, 3},
+				{"ContainerKiller(b)", true, 3, 3},
+				{"ContainerKiller(c)", true, 3, 3},
+				{"ContainerKiller(d)", true, 3, 3},
+				{"ContainerKiller(TempDirCleanUp)", true, 0, 0},
+				{"ContainerRemover(a)", true, 4, 4},
+				{"ContainerRemover(b)", true, 4, 4},
+				{"ContainerRemover(c)", true, 4, 4},
+				{"ContainerRemover(d)", true, 4, 4},
+				{"ContainerRemover(TempDirCleanUp)", true, 0, 0},
+				{"ContainerRunner(a,test)", true, 1, 1},
+				{"ContainerRunner(b,test)", true, 1, 1},
+				{"ContainerRunner(c,test)", true, 1, 1},
+				{"ContainerRunner(d,test)", true, 1, 1},
+				{"ContainerRunner(TempDirCleanUp,test)", true, 0, 0},
+			},
+		},
+		{
+			"docker-compose",
+			"docker-compose.yml",
+			"",
+			[]struct {
+				key    string
+				runner bool
+				calls  int
+				called int
+			}{
+				{"NetworkCreator(test)", true, 1, 1},
+				{"ImageExistenceChecker(db)", true, 1, 1},
+				{"ImageExistenceChecker(wordpress)", true, 1, 1},
+				{"ContainerKiller(db)", true, 2, 2},
+				{"ContainerKiller(wordpress)", true, 2, 2},
+				{"ContainerKiller(TempDirCleanUp)", true, 0, 0},
+				{"ContainerRemover(db)", true, 3, 3},
+				{"ContainerRemover(wordpress)", true, 3, 3},
+				{"ContainerRemover(TempDirCleanUp)", true, 0, 0},
+				{"ContainerRunner(db,test)", true, 1, 1},
+				{"ContainerRunner(wordpress,test)", true, 1, 1},
+				{"ContainerRunner(TempDirCleanUp,test)", true, 0, 0},
+			},
+		},
+		{
+			"partial_execution",
+			"gantry.def.yml",
+			"gantry.env.yml",
+			[]struct {
+				key    string
+				runner bool
+				calls  int
+				called int
+			}{
+				{"NetworkCreator(test)", true, 1, 1},
+				{"ImageExistenceChecker(service)", true, 1, 1},
+				{"ImageExistenceChecker(wait_for_service)", true, 1, 1},
+				{"ImageExistenceChecker(test_0)", true, 1, 1},
+				{"ImageExistenceChecker(test_1)", true, 1, 1},
+				{"ImageExistenceChecker(test_2)", true, 1, 1},
+				{"ImageExistenceChecker(test_3)", true, 1, 1},
+				{"ContainerKiller(service)", true, 3, 3},
+				{"ContainerKiller(wait_for_service)", true, 3, 3},
+				{"ContainerKiller(test_0)", true, 3, 3},
+				{"ContainerKiller(test_1)", true, 3, 3},
+				{"ContainerKiller(test_2)", true, 3, 3},
+				{"ContainerKiller(test_3)", true, 3, 3},
+				{"ContainerKiller(TempDirCleanUp)", true, 0, 0},
+				{"ContainerRemover(service)", true, 4, 4},
+				{"ContainerRemover(wait_for_service)", true, 4, 4},
+				{"ContainerRemover(test_0)", true, 4, 4},
+				{"ContainerRemover(test_1)", true, 4, 4},
+				{"ContainerRemover(test_2)", true, 4, 4},
+				{"ContainerRemover(test_3)", true, 4, 4},
+				{"ContainerRemover(TempDirCleanUp)", true, 0, 0},
+				{"ContainerRunner(service,test)", true, 1, 1},
+				{"ContainerRunner(wait_for_service,test)", true, 1, 1},
+				{"ContainerRunner(test_0,test)", true, 1, 1},
+				{"ContainerRunner(test_1,test)", true, 1, 1},
+				{"ContainerRunner(test_2,test)", true, 1, 1},
+				{"ContainerRunner(test_3,test)", true, 1, 1},
+				{"ContainerRunner(TempDirCleanUp,test)", true, 0, 0},
+			},
+		},
+		{
+			"qlever_e2e",
+			"gantry.def.yml",
+			"gantry.env.yml",
+			[]struct {
+				key    string
+				runner bool
+				calls  int
+				called int
+			}{
+				{"NetworkCreator(test)", true, 1, 1},
+				{"ImageExistenceChecker(qlever)", true, 1, 1},
+				{"ImageExistenceChecker(wait_for_qlever)", true, 0, 0},
+				{"ImageExistenceChecker(download_input)", true, 1, 1},
+				{"ImageExistenceChecker(unzip_input)", true, 1, 1},
+				{"ImageExistenceChecker(build_index)", true, 1, 1},
+				{"ImageExistenceChecker(run_queries)", true, 1, 1},
+				{"ContainerKiller(qlever)", true, 3, 3},
+				{"ContainerKiller(wait_for_qlever)", true, 3, 3},
+				{"ContainerKiller(download_input)", true, 3, 3},
+				{"ContainerKiller(unzip_input)", true, 3, 3},
+				{"ContainerKiller(build_index)", true, 3, 3},
+				{"ContainerKiller(run_queries)", true, 3, 3},
+				{"ContainerKiller(TempDirCleanUp)", true, 1, 1},
+				{"ContainerRemover(qlever)", true, 4, 4},
+				{"ContainerRemover(wait_for_qlever)", true, 4, 4},
+				{"ContainerRemover(download_input)", true, 4, 4},
+				{"ContainerRemover(unzip_input)", true, 4, 4},
+				{"ContainerRemover(build_index)", true, 4, 4},
+				{"ContainerRemover(run_queries)", true, 4, 4},
+				{"ContainerRemover(TempDirCleanUp)", true, 2, 2},
+				{"ContainerRunner(qlever,test)", true, 1, 1},
+				{"ContainerRunner(wait_for_qlever,test)", true, 1, 1},
+				{"ContainerRunner(download_input,test)", true, 1, 1},
+				{"ContainerRunner(unzip_input,test)", true, 1, 1},
+				{"ContainerRunner(build_index,test)", true, 1, 1},
+				{"ContainerRunner(run_queries,test)", true, 1, 1},
+				{"ContainerRunner(TempDirCleanUp,test)", true, 1, 1},
+			},
+		},
+		{
+			"selective_run",
+			"gantry.def.yml",
+			"gantry.env.yml",
+			[]struct {
+				key    string
+				runner bool
+				calls  int
+				called int
+			}{
+				{"NetworkCreator(test)", true, 1, 1},
+				{"ImageExistenceChecker(active_service)", true, 1, 1},
+				{"ImageExistenceChecker(new_service)", true, 1, 1},
+				{"ImageExistenceChecker(wait_for_new_service)", true, 1, 1},
+				{"ImageExistenceChecker(pre_prepare_0)", true, 1, 1},
+				{"ImageExistenceChecker(pre_prepare_1)", true, 1, 1},
+				{"ImageExistenceChecker(prepare_new_service_version)", true, 1, 1},
+				{"ImageExistenceChecker(test_new_service)", true, 1, 1},
+				{"ImageExistenceChecker(move_data_to_active_service)", true, 1, 1},
+				{"ContainerKiller(active_service)", true, 1, 1},
+				{"ContainerKiller(new_service)", true, 3, 3},
+				{"ContainerKiller(wait_for_new_service)", true, 3, 3},
+				{"ContainerKiller(pre_prepare_0)", true, 3, 3},
+				{"ContainerKiller(pre_prepare_1)", true, 3, 3},
+				{"ContainerKiller(prepare_new_service_version)", true, 3, 3},
+				{"ContainerKiller(test_new_service)", true, 3, 3},
+				{"ContainerKiller(move_data_to_active_service)", true, 3, 3},
+				{"ContainerKiller(TempDirCleanUp)", true, 0, 0},
+				{"ContainerRemover(active_service)", true, 1, 1},
+				{"ContainerRemover(new_service)", true, 4, 4},
+				{"ContainerRemover(wait_for_new_service)", true, 4, 4},
+				{"ContainerRemover(pre_prepare_0)", true, 4, 4},
+				{"ContainerRemover(pre_prepare_1)", true, 4, 4},
+				{"ContainerRemover(prepare_new_service_version)", true, 4, 4},
+				{"ContainerRemover(test_new_service)", true, 4, 4},
+				{"ContainerRemover(move_data_to_active_service)", true, 4, 4},
+				{"ContainerRemover(TempDirCleanUp)", true, 0, 0},
+				{"ContainerRunner(active_service,test)", true, 1, 1},
+				{"ContainerRunner(new_service,test)", true, 1, 1},
+				{"ContainerRunner(wait_for_new_service,test)", true, 1, 1},
+				{"ContainerRunner(pre_prepare_0,test)", true, 1, 1},
+				{"ContainerRunner(pre_prepare_1,test)", true, 1, 1},
+				{"ContainerRunner(prepare_new_service_version,test)", true, 1, 1},
+				{"ContainerRunner(test_new_service,test)", true, 1, 1},
+				{"ContainerRunner(move_data_to_active_service,test)", true, 1, 1},
+				{"ContainerRunner(TempDirCleanUp,test)", true, 0, 0},
+			},
+		},
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, example := range examples {
+		if err := os.Chdir(filepath.Join(cwd, "examples", example.dir)); err != nil {
+			log.Fatal(err)
+		}
+		p, err := NewPipeline(example.def, example.env, types.MappingWithEquals{}, types.StringSet{}, types.StringSet{})
+		if err != nil {
+			t.Errorf("Unexpected error creating pipeline for '%s': '%#v'", example.dir, err)
+		}
+		localRunner := NewNoopRunner(false)
+		noopRunner := NewNoopRunner(false)
+		p.localRunner = localRunner
+		p.noopRunner = noopRunner
+		p.Network = Network("test")
+
+		if err := p.KillContainers(true); err != nil {
+			t.Errorf("Unexpected error in '%s', got: '%#v', wanted 'nil'", example.dir, err)
+		}
+		if err := p.RemoveContainers(true); err != nil {
+			t.Errorf("Unexpected error in '%s', got: '%#v', wanted 'nil'", example.dir, err)
+		}
+		if err := p.PullImages(false); err != nil {
+			t.Errorf("Unexpected error in '%s', got: '%#v', wanted 'nil'", example.dir, err)
+		}
+		if err := p.BuildImages(false); err != nil {
+			t.Errorf("Unexpected error in '%s', got: '%#v', wanted 'nil'", example.dir, err)
+		}
+		if err := p.CreateNetwork(); err != nil {
+			t.Errorf("Unexpected error in '%s', got: '%#v', wanted 'nil'", example.dir, err)
+		}
+		if err := p.ExecuteSteps(); err != nil {
+			t.Errorf("Unexpected error in '%s', got: '%#v', wanted 'nil'", example.dir, err)
+		}
+		if err := p.CleanUp(syscall.SIGKILL); err != nil {
+			t.Errorf("Unexpected error in '%s', got: '%#v', wanted 'nil'", example.dir, err)
+		}
+
+		for _, c := range example.cases {
+			runner := noopRunner
+			if c.runner {
+				runner = localRunner
+			}
+			if v := runner.NumCalls(c.key); v != c.calls {
+				t.Errorf("Incorrect NumCalls for '%s' in '%s', got: '%d', wanted '%d'", c.key, example.dir, v, c.calls)
+			}
+			if v := runner.NumCalled(c.key); v != c.called {
+				t.Errorf("Incorrect NumCalled for '%s' in '%s', got: '%d', wanted '%d'", c.key, example.dir, v, c.called)
+			}
+		}
+		if err := os.Chdir(cwd); err != nil {
+			log.Fatal(err)
+		}
+	}
+}

--- a/pipeline_internal_test.go
+++ b/pipeline_internal_test.go
@@ -1,0 +1,787 @@
+package gantry
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/ad-freiburg/gantry/types"
+)
+
+const def = `steps:
+  a:
+    image: alpine
+  b:
+    image: alpine
+    after:
+      - a
+services:
+  c:
+    build:
+      context: ./dummy
+    depends_on:
+      - b
+`
+const env = `steps:
+  b:
+    ignore: true
+services:
+  c:
+    keep_alive: replace
+`
+
+func TestPipelineGetRunnerForMeta(t *testing.T) {
+	tmpDef, err := ioutil.TempFile("", "def")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpDef.Name())
+	err = ioutil.WriteFile(tmpDef.Name(), []byte(def), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	tmpEnv, err := ioutil.TempFile("", "env")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpEnv.Name())
+	err = ioutil.WriteFile(tmpEnv.Name(), []byte(env), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	p, err := NewPipeline(tmpDef.Name(), tmpEnv.Name(), types.MappingWithEquals{}, types.StringSet{}, types.StringSet{})
+	if err != nil {
+		t.Errorf("Unexpected error creating pipeline: '%#v'", err)
+	}
+	localRunner := NewNoopRunner(false)
+	p.localRunner = localRunner
+	noopRunner := NewNoopRunner(false)
+	p.noopRunner = noopRunner
+
+	cases := []struct {
+		stepname string
+		runner   *NoopRunner
+	}{
+		{"a", localRunner},
+		{"b", noopRunner},
+		{"c", localRunner},
+	}
+
+	for _, c := range cases {
+		if v := p.GetRunnerForMeta(p.Definition.Steps[c.stepname].Meta); v != c.runner {
+			t.Errorf("Incorrect runner for '%s', got: '%#v', wanted '%#v'", c.stepname, v, c.runner)
+		}
+	}
+}
+
+func TestPipelineBuildImages(t *testing.T) {
+	tmpDef, err := ioutil.TempFile("", "def")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpDef.Name())
+	err = ioutil.WriteFile(tmpDef.Name(), []byte(def), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	tmpEnv, err := ioutil.TempFile("", "env")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpEnv.Name())
+	err = ioutil.WriteFile(tmpEnv.Name(), []byte(env), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	p, err := NewPipeline(tmpDef.Name(), tmpEnv.Name(), types.MappingWithEquals{}, types.StringSet{}, types.StringSet{})
+	if err != nil {
+		t.Errorf("Unexpected error creating pipeline: '%#v'", err)
+	}
+	localRunner := NewNoopRunner(false)
+	p.localRunner = localRunner
+	noopRunner := NewNoopRunner(false)
+	p.noopRunner = noopRunner
+
+	cases := []struct {
+		key    string
+		runner *NoopRunner
+		calls  int
+		called int
+	}{
+		{"ImageBuilder(c)", localRunner, 0, 0},
+	}
+
+	if err := p.BuildImages(false); err != nil {
+		t.Errorf("Unexpected error, got: '%#v', wanted 'nil'", err)
+	}
+	for _, c := range cases {
+		if v := c.runner.NumCalls(c.key); v != c.calls {
+			t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", c.key, v, c.calls)
+		}
+		if v := c.runner.NumCalled(c.key); v != c.called {
+			t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", c.key, v, c.called)
+		}
+	}
+}
+
+func TestPipelineBuildImagesForced(t *testing.T) {
+	tmpDef, err := ioutil.TempFile("", "def")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpDef.Name())
+	err = ioutil.WriteFile(tmpDef.Name(), []byte(def), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	tmpEnv, err := ioutil.TempFile("", "env")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpEnv.Name())
+	err = ioutil.WriteFile(tmpEnv.Name(), []byte(env), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	p, err := NewPipeline(tmpDef.Name(), tmpEnv.Name(), types.MappingWithEquals{}, types.StringSet{}, types.StringSet{})
+	if err != nil {
+		t.Errorf("Unexpected error creating pipeline: '%#v'", err)
+	}
+	localRunner := NewNoopRunner(false)
+	p.localRunner = localRunner
+	noopRunner := NewNoopRunner(false)
+	p.noopRunner = noopRunner
+
+	cases := []struct {
+		key    string
+		runner *NoopRunner
+		calls  int
+		called int
+	}{
+		{"ImageBuilder(c)", localRunner, 0, 0},
+	}
+
+	if err := p.BuildImages(true); err != nil {
+		t.Errorf("Unexpected error, got: '%#v', wanted 'nil'", err)
+	}
+	for _, c := range cases {
+		if v := c.runner.NumCalls(c.key); v != c.calls {
+			t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", c.key, v, c.calls)
+		}
+		if v := c.runner.NumCalled(c.key); v != c.called {
+			t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", c.key, v, c.called)
+		}
+	}
+}
+
+func TestPipelinePullImages(t *testing.T) {
+	tmpDef, err := ioutil.TempFile("", "def")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpDef.Name())
+	err = ioutil.WriteFile(tmpDef.Name(), []byte(def), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	tmpEnv, err := ioutil.TempFile("", "env")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpEnv.Name())
+	err = ioutil.WriteFile(tmpEnv.Name(), []byte(env), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	p, err := NewPipeline(tmpDef.Name(), tmpEnv.Name(), types.MappingWithEquals{}, types.StringSet{}, types.StringSet{})
+	if err != nil {
+		t.Errorf("Unexpected error creating pipeline: '%#v'", err)
+	}
+	localRunner := NewNoopRunner(false)
+	p.localRunner = localRunner
+	noopRunner := NewNoopRunner(false)
+	p.noopRunner = noopRunner
+
+	cases := []struct {
+		key    string
+		runner *NoopRunner
+		calls  int
+		called int
+	}{
+		{"ImageExistenceChecker(a)", localRunner, 1, 1},
+		{"ImageExistenceChecker(b)", noopRunner, 1, 1},
+		{"ImageExistenceChecker(c)", localRunner, 0, 0},
+		{"ImagePuller(a)", localRunner, 0, 0},
+		{"ImagePuller(b)", noopRunner, 0, 0},
+		{"ImagePuller(c)", localRunner, 0, 0},
+	}
+
+	if err := p.PullImages(false); err != nil {
+		t.Errorf("Unexpected error, got: '%#v', wanted 'nil'", err)
+	}
+	for _, c := range cases {
+		if v := c.runner.NumCalls(c.key); v != c.calls {
+			t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", c.key, v, c.calls)
+		}
+		if v := c.runner.NumCalled(c.key); v != c.called {
+			t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", c.key, v, c.called)
+		}
+	}
+}
+
+func TestPipelinePullImagesForced(t *testing.T) {
+	tmpDef, err := ioutil.TempFile("", "def")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpDef.Name())
+	err = ioutil.WriteFile(tmpDef.Name(), []byte(def), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	tmpEnv, err := ioutil.TempFile("", "env")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpEnv.Name())
+	err = ioutil.WriteFile(tmpEnv.Name(), []byte(env), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	p, err := NewPipeline(tmpDef.Name(), tmpEnv.Name(), types.MappingWithEquals{}, types.StringSet{}, types.StringSet{})
+	if err != nil {
+		t.Errorf("Unexpected error creating pipeline: '%#v'", err)
+	}
+	localRunner := NewNoopRunner(false)
+	p.localRunner = localRunner
+	noopRunner := NewNoopRunner(false)
+	p.noopRunner = noopRunner
+
+	cases := []struct {
+		key    string
+		runner *NoopRunner
+		calls  int
+		called int
+	}{
+		{"ImageExistenceChecker(a)", localRunner, 1, 1},
+		{"ImageExistenceChecker(b)", noopRunner, 1, 1},
+		{"ImageExistenceChecker(c)", localRunner, 0, 0},
+		{"ImagePuller(a)", localRunner, 1, 1},
+		{"ImagePuller(b)", noopRunner, 1, 1},
+		{"ImagePuller(c)", localRunner, 0, 0},
+	}
+
+	if err := p.PullImages(true); err != nil {
+		t.Errorf("Unexpected error, got: '%#v', wanted 'nil'", err)
+	}
+	for _, c := range cases {
+		if v := c.runner.NumCalls(c.key); v != c.calls {
+			t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", c.key, v, c.calls)
+		}
+		if v := c.runner.NumCalled(c.key); v != c.called {
+			t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", c.key, v, c.called)
+		}
+	}
+}
+
+func TestPipelineKillContainers(t *testing.T) {
+	tmpDef, err := ioutil.TempFile("", "def")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpDef.Name())
+	err = ioutil.WriteFile(tmpDef.Name(), []byte(def), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	tmpEnv, err := ioutil.TempFile("", "env")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpEnv.Name())
+	err = ioutil.WriteFile(tmpEnv.Name(), []byte(env), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	p, err := NewPipeline(tmpDef.Name(), tmpEnv.Name(), types.MappingWithEquals{}, types.StringSet{}, types.StringSet{})
+	if err != nil {
+		t.Errorf("Unexpected error creating pipeline: '%#v'", err)
+	}
+	localRunner := NewNoopRunner(false)
+	p.localRunner = localRunner
+	noopRunner := NewNoopRunner(false)
+	p.noopRunner = noopRunner
+
+	cases := []struct {
+		key    string
+		runner *NoopRunner
+		calls  int
+		called int
+	}{
+		{"ContainerKiller(a)", localRunner, 1, 1},
+		{"ContainerKiller(b)", noopRunner, 1, 1},
+		{"ContainerKiller(c)", localRunner, 1, 1},
+		{"ContainerRemover(a)", localRunner, 1, 1},
+		{"ContainerRemover(b)", noopRunner, 1, 1},
+		{"ContainerRemover(c)", localRunner, 1, 1},
+	}
+
+	if err := p.KillContainers(false); err != nil {
+		t.Errorf("Unexpected error, got: '%#v', wanted 'nil'", err)
+	}
+	for _, c := range cases {
+		if v := c.runner.NumCalls(c.key); v != c.calls {
+			t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", c.key, v, c.calls)
+		}
+		if v := c.runner.NumCalled(c.key); v != c.called {
+			t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", c.key, v, c.called)
+		}
+	}
+}
+
+func TestPipelineKillContainersPreRun(t *testing.T) {
+	tmpDef, err := ioutil.TempFile("", "def")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpDef.Name())
+	err = ioutil.WriteFile(tmpDef.Name(), []byte(def), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	tmpEnv, err := ioutil.TempFile("", "env")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpEnv.Name())
+	err = ioutil.WriteFile(tmpEnv.Name(), []byte(env), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	p, err := NewPipeline(tmpDef.Name(), tmpEnv.Name(), types.MappingWithEquals{}, types.StringSet{}, types.StringSet{})
+	if err != nil {
+		t.Errorf("Unexpected error creating pipeline: '%#v'", err)
+	}
+	localRunner := NewNoopRunner(false)
+	p.localRunner = localRunner
+	noopRunner := NewNoopRunner(false)
+	p.noopRunner = noopRunner
+
+	cases := []struct {
+		key    string
+		runner *NoopRunner
+		calls  int
+		called int
+	}{
+		{"ContainerKiller(a)", localRunner, 1, 1},
+		{"ContainerKiller(b)", noopRunner, 1, 1},
+		{"ContainerKiller(c)", localRunner, 0, 0},
+		{"ContainerRemover(a)", localRunner, 1, 1},
+		{"ContainerRemover(b)", noopRunner, 1, 1},
+		{"ContainerRemover(c)", localRunner, 0, 0},
+	}
+
+	if err := p.KillContainers(true); err != nil {
+		t.Errorf("Unexpected error, got: '%#v', wanted 'nil'", err)
+	}
+	for _, c := range cases {
+		if v := c.runner.NumCalls(c.key); v != c.calls {
+			t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", c.key, v, c.calls)
+		}
+		if v := c.runner.NumCalled(c.key); v != c.called {
+			t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", c.key, v, c.called)
+		}
+	}
+}
+
+func TestPipelineRemoveContainers(t *testing.T) {
+	tmpDef, err := ioutil.TempFile("", "def")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpDef.Name())
+	err = ioutil.WriteFile(tmpDef.Name(), []byte(def), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	tmpEnv, err := ioutil.TempFile("", "env")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpEnv.Name())
+	err = ioutil.WriteFile(tmpEnv.Name(), []byte(env), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	p, err := NewPipeline(tmpDef.Name(), tmpEnv.Name(), types.MappingWithEquals{}, types.StringSet{}, types.StringSet{})
+	if err != nil {
+		t.Errorf("Unexpected error creating pipeline: '%#v'", err)
+	}
+	localRunner := NewNoopRunner(false)
+	p.localRunner = localRunner
+	noopRunner := NewNoopRunner(false)
+	p.noopRunner = noopRunner
+
+	cases := []struct {
+		key    string
+		runner *NoopRunner
+		calls  int
+		called int
+	}{
+		{"ContainerRemover(a)", localRunner, 1, 1},
+		{"ContainerRemover(b)", noopRunner, 1, 1},
+		{"ContainerRemover(c)", localRunner, 1, 1},
+	}
+
+	if err := p.RemoveContainers(false); err != nil {
+		t.Errorf("Unexpected error, got: '%#v', wanted 'nil'", err)
+	}
+	for _, c := range cases {
+		if v := c.runner.NumCalls(c.key); v != c.calls {
+			t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", c.key, v, c.calls)
+		}
+		if v := c.runner.NumCalled(c.key); v != c.called {
+			t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", c.key, v, c.called)
+		}
+	}
+}
+
+func TestPipelineRemoveContainersPreRun(t *testing.T) {
+	tmpDef, err := ioutil.TempFile("", "def")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpDef.Name())
+	err = ioutil.WriteFile(tmpDef.Name(), []byte(def), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	tmpEnv, err := ioutil.TempFile("", "env")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpEnv.Name())
+	err = ioutil.WriteFile(tmpEnv.Name(), []byte(env), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	p, err := NewPipeline(tmpDef.Name(), tmpEnv.Name(), types.MappingWithEquals{}, types.StringSet{}, types.StringSet{})
+	if err != nil {
+		t.Errorf("Unexpected error creating pipeline: '%#v'", err)
+	}
+	localRunner := NewNoopRunner(false)
+	p.localRunner = localRunner
+	noopRunner := NewNoopRunner(false)
+	p.noopRunner = noopRunner
+
+	cases := []struct {
+		key    string
+		runner *NoopRunner
+		calls  int
+		called int
+	}{
+		{"ContainerRemover(a)", localRunner, 1, 1},
+		{"ContainerRemover(b)", noopRunner, 1, 1},
+		{"ContainerRemover(c)", localRunner, 0, 0},
+	}
+
+	if err := p.RemoveContainers(true); err != nil {
+		t.Errorf("Unexpected error, got: '%#v', wanted 'nil'", err)
+	}
+	for _, c := range cases {
+		if v := c.runner.NumCalls(c.key); v != c.calls {
+			t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", c.key, v, c.calls)
+		}
+		if v := c.runner.NumCalled(c.key); v != c.called {
+			t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", c.key, v, c.called)
+		}
+	}
+}
+
+func TestPipelineCreateNetwork(t *testing.T) {
+	tmpDef, err := ioutil.TempFile("", "def")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpDef.Name())
+	err = ioutil.WriteFile(tmpDef.Name(), []byte(def), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	tmpEnv, err := ioutil.TempFile("", "env")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpEnv.Name())
+	err = ioutil.WriteFile(tmpEnv.Name(), []byte(env), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	p, err := NewPipeline(tmpDef.Name(), tmpEnv.Name(), types.MappingWithEquals{}, types.StringSet{}, types.StringSet{})
+	if err != nil {
+		t.Errorf("Unexpected error creating pipeline: '%#v'", err)
+	}
+	localRunner := NewNoopRunner(false)
+	p.localRunner = localRunner
+	noopRunner := NewNoopRunner(false)
+	p.noopRunner = noopRunner
+	p.Network = Network("test")
+
+	cases := []struct {
+		key    string
+		runner *NoopRunner
+		calls  int
+		called int
+	}{
+		{"NetworkCreator(test)", localRunner, 1, 1},
+	}
+
+	if err := p.CreateNetwork(); err != nil {
+		t.Errorf("Unexpected error, got: '%#v', wanted 'nil'", err)
+	}
+	for _, c := range cases {
+		if v := c.runner.NumCalls(c.key); v != c.calls {
+			t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", c.key, v, c.calls)
+		}
+		if v := c.runner.NumCalled(c.key); v != c.called {
+			t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", c.key, v, c.called)
+		}
+	}
+}
+
+func TestPipelineRemoveNetwork(t *testing.T) {
+	tmpDef, err := ioutil.TempFile("", "def")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpDef.Name())
+	err = ioutil.WriteFile(tmpDef.Name(), []byte(def), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	tmpEnv, err := ioutil.TempFile("", "env")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpEnv.Name())
+	err = ioutil.WriteFile(tmpEnv.Name(), []byte(env), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	p, err := NewPipeline(tmpDef.Name(), tmpEnv.Name(), types.MappingWithEquals{}, types.StringSet{}, types.StringSet{})
+	if err != nil {
+		t.Errorf("Unexpected error creating pipeline: '%#v'", err)
+	}
+	localRunner := NewNoopRunner(false)
+	p.localRunner = localRunner
+	noopRunner := NewNoopRunner(false)
+	p.noopRunner = noopRunner
+	p.Network = Network("test")
+
+	cases := []struct {
+		key    string
+		runner *NoopRunner
+		calls  int
+		called int
+	}{
+		{"NetworkRemover(test)", localRunner, 1, 1},
+	}
+
+	if err := p.RemoveNetwork(); err != nil {
+		t.Errorf("Unexpected error, got: '%#v', wanted 'nil'", err)
+	}
+	for _, c := range cases {
+		if v := c.runner.NumCalls(c.key); v != c.calls {
+			t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", c.key, v, c.calls)
+		}
+		if v := c.runner.NumCalled(c.key); v != c.called {
+			t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", c.key, v, c.called)
+		}
+	}
+}
+
+func TestPipelineExecuteSteps(t *testing.T) {
+	tmpDef, err := ioutil.TempFile("", "def")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpDef.Name())
+	err = ioutil.WriteFile(tmpDef.Name(), []byte(def), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	tmpEnv, err := ioutil.TempFile("", "env")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpEnv.Name())
+	err = ioutil.WriteFile(tmpEnv.Name(), []byte(env), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	p, err := NewPipeline(tmpDef.Name(), tmpEnv.Name(), types.MappingWithEquals{}, types.StringSet{}, types.StringSet{})
+	if err != nil {
+		t.Errorf("Unexpected error creating pipeline: '%#v'", err)
+	}
+	localRunner := NewNoopRunner(false)
+	p.localRunner = localRunner
+	noopRunner := NewNoopRunner(false)
+	p.noopRunner = noopRunner
+	p.Network = Network("test")
+
+	cases := []struct {
+		key    string
+		runner *NoopRunner
+		calls  int
+		called int
+	}{
+		{"ContainerKiller(a)", localRunner, 1, 1},
+		{"ContainerRemover(a)", localRunner, 1, 1},
+		{"ContainerRunner(a,test)", localRunner, 1, 1},
+		{"ContainerKiller(b)", noopRunner, 1, 1},
+		{"ContainerRemover(b)", noopRunner, 1, 1},
+		{"ContainerRunner(b,test)", noopRunner, 1, 1},
+		{"ContainerKiller(c)", localRunner, 1, 1},
+		{"ContainerRemover(c)", localRunner, 1, 1},
+		{"ContainerRunner(c,test)", localRunner, 1, 1},
+	}
+
+	if err := p.ExecuteSteps(); err != nil {
+		t.Errorf("Unexpected error, got: '%#v', wanted 'nil'", err)
+	}
+	for _, c := range cases {
+		if v := c.runner.NumCalls(c.key); v != c.calls {
+			t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", c.key, v, c.calls)
+		}
+		if v := c.runner.NumCalled(c.key); v != c.called {
+			t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", c.key, v, c.called)
+		}
+	}
+}
+
+func TestPipelineRemoveTempDirData(t *testing.T) {
+	tmpDef, err := ioutil.TempFile("", "def")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpDef.Name())
+	err = ioutil.WriteFile(tmpDef.Name(), []byte(`steps:
+  a:
+    volumes:
+    - {{ TempDir }}:/input
+`), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	tmpEnv, err := ioutil.TempFile("", "env")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpEnv.Name())
+	err = ioutil.WriteFile(tmpEnv.Name(), []byte(""), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	p, err := NewPipeline(tmpDef.Name(), tmpEnv.Name(), types.MappingWithEquals{}, types.StringSet{}, types.StringSet{})
+	if err != nil {
+		t.Errorf("Unexpected error creating pipeline: '%#v'", err)
+	}
+	localRunner := NewNoopRunner(false)
+	p.localRunner = localRunner
+	noopRunner := NewNoopRunner(false)
+	p.noopRunner = noopRunner
+	p.Network = Network("test")
+
+	cases := []struct {
+		key    string
+		runner *NoopRunner
+		calls  int
+		called int
+	}{
+		{"ContainerKiller(TempDirCleanUp)", localRunner, 1, 1},
+		{"ContainerRemover(TempDirCleanUp)", localRunner, 2, 2},
+		{"ContainerRunner(TempDirCleanUp,test)", localRunner, 1, 1},
+	}
+
+	if err := p.RemoveTempDirData(); err != nil {
+		t.Errorf("Unexpected error, got: '%#v', wanted 'nil'", err)
+	}
+	for _, c := range cases {
+		if v := c.runner.NumCalls(c.key); v != c.calls {
+			t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", c.key, v, c.calls)
+		}
+		if v := c.runner.NumCalled(c.key); v != c.called {
+			t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", c.key, v, c.called)
+		}
+	}
+}
+
+func TestPipelineRemoveTempDirDataNoTempDirs(t *testing.T) {
+	tmpDef, err := ioutil.TempFile("", "def")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpDef.Name())
+	err = ioutil.WriteFile(tmpDef.Name(), []byte(`steps:
+  a:
+`), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+	tmpEnv, err := ioutil.TempFile("", "env")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.Remove(tmpEnv.Name())
+	err = ioutil.WriteFile(tmpEnv.Name(), []byte(""), 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	p, err := NewPipeline(tmpDef.Name(), tmpEnv.Name(), types.MappingWithEquals{}, types.StringSet{}, types.StringSet{})
+	if err != nil {
+		t.Errorf("Unexpected error creating pipeline: '%#v'", err)
+	}
+	localRunner := NewNoopRunner(false)
+	p.localRunner = localRunner
+	noopRunner := NewNoopRunner(false)
+	p.noopRunner = noopRunner
+	p.Network = Network("test")
+
+	cases := []struct {
+		key    string
+		runner *NoopRunner
+		calls  int
+		called int
+	}{
+		{"ContainerKiller(TempDirCleanUp)", localRunner, 0, 0},
+		{"ContainerRemover(TempDirCleanUp)", localRunner, 0, 0},
+		{"ContainerRunner(TempDirCleanUp,test)", localRunner, 0, 0},
+	}
+
+	if err := p.RemoveTempDirData(); err != nil {
+		t.Errorf("Unexpected error, got: '%#v', wanted 'nil'", err)
+	}
+	for _, c := range cases {
+		if v := c.runner.NumCalls(c.key); v != c.calls {
+			t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", c.key, v, c.calls)
+		}
+		if v := c.runner.NumCalled(c.key); v != c.called {
+			t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", c.key, v, c.called)
+		}
+	}
+}

--- a/runner_test.go
+++ b/runner_test.go
@@ -1,0 +1,290 @@
+package gantry_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ad-freiburg/gantry"
+)
+
+func TestNoopRunnerImageBuilder(t *testing.T) {
+	runner := gantry.NewNoopRunner(true)
+	step := gantry.Step{}
+	step.Name = "step"
+	key := fmt.Sprintf("ImageBuilder(%s,%t)", step.Name, false)
+	if c := runner.NumCalls(key); c != 0 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+	if c := runner.NumCalled(key); c != 0 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+
+	f := runner.ImageBuilder(step, false)
+	if c := runner.NumCalls(key); c != 1 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+	if c := runner.NumCalled(key); c != 0 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+
+	if err := f(); err != nil {
+		t.Errorf("Unexpected error, got: '%#v', wanted 'nil'", err)
+	}
+	if c := runner.NumCalls(key); c != 1 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+	if c := runner.NumCalled(key); c != 1 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+}
+
+func TestNoopRunnerImageBuilderForcePull(t *testing.T) {
+	runner := gantry.NewNoopRunner(true)
+	step := gantry.Step{}
+	step.Name = "step"
+	key := fmt.Sprintf("ImageBuilder(%s,%t)", step.Name, true)
+	if c := runner.NumCalls(key); c != 0 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+	if c := runner.NumCalled(key); c != 0 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+
+	f := runner.ImageBuilder(step, true)
+	if c := runner.NumCalls(key); c != 1 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+	if c := runner.NumCalled(key); c != 0 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+
+	if err := f(); err != nil {
+		t.Errorf("Unexpected error, got: '%#v', wanted 'nil'", err)
+	}
+	if c := runner.NumCalls(key); c != 1 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+	if c := runner.NumCalled(key); c != 1 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+}
+
+func TestNoopRunnerImagePuller(t *testing.T) {
+	runner := gantry.NewNoopRunner(true)
+	step := gantry.Step{}
+	step.Name = "step"
+	key := fmt.Sprintf("ImagePuller(%s)", step.Name)
+	if c := runner.NumCalls(key); c != 0 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+	if c := runner.NumCalled(key); c != 0 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+
+	f := runner.ImagePuller(step)
+	if c := runner.NumCalls(key); c != 1 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+	if c := runner.NumCalled(key); c != 0 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+
+	if err := f(); err != nil {
+		t.Errorf("Unexpected error, got: '%#v', wanted 'nil'", err)
+	}
+	if c := runner.NumCalls(key); c != 1 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+	if c := runner.NumCalled(key); c != 1 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+}
+
+func TestNoopRunnerImageExistenceChecker(t *testing.T) {
+	runner := gantry.NewNoopRunner(true)
+	step := gantry.Step{}
+	step.Name = "step"
+	key := fmt.Sprintf("ImageExistenceChecker(%s)", step.Name)
+	if c := runner.NumCalls(key); c != 0 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+	if c := runner.NumCalled(key); c != 0 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+
+	f := runner.ImageExistenceChecker(step)
+	if c := runner.NumCalls(key); c != 1 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+	if c := runner.NumCalled(key); c != 0 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+
+	if err := f(); err != nil {
+		t.Errorf("Unexpected error, got: '%#v', wanted 'nil'", err)
+	}
+	if c := runner.NumCalls(key); c != 1 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+	if c := runner.NumCalled(key); c != 1 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+}
+
+func TestNoopRunnerContainerKiller(t *testing.T) {
+	runner := gantry.NewNoopRunner(true)
+	step := gantry.Step{}
+	step.Name = "step"
+	key := fmt.Sprintf("ContainerKiller(%s)", step.Name)
+	if c := runner.NumCalls(key); c != 0 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+	if c := runner.NumCalled(key); c != 0 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+
+	f := runner.ContainerKiller(step)
+	if c := runner.NumCalls(key); c != 1 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+	if c := runner.NumCalled(key); c != 0 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+
+	num, err := f()
+	if err != nil {
+		t.Errorf("Unexpected error, got: '%#v', wanted 'nil'", err)
+	}
+	if num != 0 {
+		t.Errorf("Incorrect number of killed containers, got: '%#v', wanted '0'", num)
+	}
+	if c := runner.NumCalls(key); c != 1 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+	if c := runner.NumCalled(key); c != 1 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+}
+
+func TestNoopRunnerContainerRemover(t *testing.T) {
+	runner := gantry.NewNoopRunner(true)
+	step := gantry.Step{}
+	step.Name = "step"
+	key := fmt.Sprintf("ContainerRemover(%s)", step.Name)
+	if c := runner.NumCalls(key); c != 0 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+	if c := runner.NumCalled(key); c != 0 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+
+	f := runner.ContainerRemover(step)
+	if c := runner.NumCalls(key); c != 1 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+	if c := runner.NumCalled(key); c != 0 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+
+	if err := f(); err != nil {
+		t.Errorf("Unexpected error, got: '%#v', wanted 'nil'", err)
+	}
+	if c := runner.NumCalls(key); c != 1 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+	if c := runner.NumCalled(key); c != 1 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+}
+
+func TestNoopRunnerContainerRunner(t *testing.T) {
+	runner := gantry.NewNoopRunner(true)
+	step := gantry.Step{}
+	step.Name = "step"
+	network := gantry.Network("network")
+	key := fmt.Sprintf("ContainerRunner(%s,%s)", step.Name, network)
+	if c := runner.NumCalls(key); c != 0 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+	if c := runner.NumCalled(key); c != 0 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+
+	f := runner.ContainerRunner(step, network)
+	if c := runner.NumCalls(key); c != 1 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+	if c := runner.NumCalled(key); c != 0 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+
+	if err := f(); err != nil {
+		t.Errorf("Unexpected error, got: '%#v', wanted 'nil'", err)
+	}
+	if c := runner.NumCalls(key); c != 1 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+	if c := runner.NumCalled(key); c != 1 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+}
+
+func TestNoopRunnerNetworkCreator(t *testing.T) {
+	runner := gantry.NewNoopRunner(true)
+	network := gantry.Network("network")
+	key := fmt.Sprintf("NetworkCreator(%s)", network)
+	if c := runner.NumCalls(key); c != 0 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+	if c := runner.NumCalled(key); c != 0 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+
+	f := runner.NetworkCreator(network)
+	if c := runner.NumCalls(key); c != 1 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+	if c := runner.NumCalled(key); c != 0 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+
+	if err := f(); err != nil {
+		t.Errorf("Unexpected error, got: '%#v', wanted 'nil'", err)
+	}
+	if c := runner.NumCalls(key); c != 1 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+	if c := runner.NumCalled(key); c != 1 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+}
+
+func TestNoopRunnerNetworkRemover(t *testing.T) {
+	runner := gantry.NewNoopRunner(true)
+	network := gantry.Network("network")
+	key := fmt.Sprintf("NetworkRemover(%s)", network)
+	if c := runner.NumCalls(key); c != 0 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+	if c := runner.NumCalled(key); c != 0 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+
+	f := runner.NetworkRemover(network)
+	if c := runner.NumCalls(key); c != 1 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+	if c := runner.NumCalled(key); c != 0 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 0)
+	}
+
+	if err := f(); err != nil {
+		t.Errorf("Unexpected error, got: '%#v', wanted 'nil'", err)
+	}
+	if c := runner.NumCalls(key); c != 1 {
+		t.Errorf("Incorrect NumCalls for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+	if c := runner.NumCalled(key); c != 1 {
+		t.Errorf("Incorrect NumCalled for '%s', got: '%d', wanted '%d'", key, c, 1)
+	}
+}


### PR DESCRIPTION
This PR adds tests for the main pipeline logic

NoopRunner now counts number of invocations thus no separate test runner is needed.