### PR TITLE
Add go 1.13 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 
 go:
   - "1.12.x"
+  - "1.13.x"
   - "master"
 
 notifications:


### PR DESCRIPTION
As [go1.13](https://blog.golang.org/go1.13) is released, this PR adds it travis to run checks against this version too.