### PR TITLE
Adds option to print names, fixes bug killing too many containers.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -113,6 +113,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&envFile, "global-environment", "g", "", fmt.Sprintf("Explicit %s to use", gantry.GantryEnv))
 	rootCmd.PersistentFlags().StringVarP(&gantry.ProjectName, "project-name", "p", "", "Spefify an alternate project name")
 	rootCmd.PersistentFlags().BoolVar(&gantry.Verbose, "verbose", false, "Verbose output")
+	rootCmd.PersistentFlags().BoolVar(&gantry.ShowContainerCommands, "show-container-commands", false, "Print commands used to interact with containers")
 	rootCmd.PersistentFlags().BoolVar(&gantry.ForceWharfer, "force-wharfer", false, "Force usage of wharfer")
 	rootCmd.PersistentFlags().StringArrayVarP(&stepsToIgnore, "ignore", "i", []string{}, "Ignore step/service with this name")
 	rootCmd.PersistentFlags().StringArrayVarP(&environment, "env", "e", []string{}, "Set environment variables")

--- a/constants.go
+++ b/constants.go
@@ -19,6 +19,8 @@ var (
 	Version = "no-version"
 	// Verbose is a global verbosity flag
 	Verbose = false
+	// ShowContainerCommands is a global flag to signal printing of commands run.
+	ShowContainerCommands = false
 	// ProjectName stores the global prefix for networks and containers.
 	ProjectName = ""
 	// ForceWharfer is a global flag to force the usage of wharfer even

--- a/runner.go
+++ b/runner.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os/exec"
 	"os/user"
+	"strings"
 	"sync"
 )
 
@@ -221,7 +222,11 @@ func NewLocalRunner(prefix string, stdout io.Writer, stderr io.Writer) *LocalRun
 
 // Exec executes given arguments with the containerExecutable.
 func (r *LocalRunner) Exec(args []string) error {
-	cmd := exec.Command(getContainerExecutable(), args...)
+	ce := getContainerExecutable()
+	if ShowContainerCommands {
+		log.Printf("Exec:   %s %s", ce, strings.Join(args, " "))
+	}
+	cmd := exec.Command(ce, args...)
 	stdout := NewPrefixedLogger(r.prefix, log.New(r.stdout, "", log.LstdFlags))
 	stderr := NewPrefixedLogger(r.prefix, log.New(r.stderr, "", log.LstdFlags))
 	cmd.Stdout = stdout
@@ -231,7 +236,11 @@ func (r *LocalRunner) Exec(args []string) error {
 
 // Output executes given arguments with the containerExecutable and returns the output.
 func (r *LocalRunner) Output(args []string) ([]byte, error) {
-	cmd := exec.Command(getContainerExecutable(), args...)
+	ce := getContainerExecutable()
+	if ShowContainerCommands {
+		log.Printf("Output: %s %s", ce, strings.Join(args, " "))
+	}
+	cmd := exec.Command(ce, args...)
 	return cmd.Output()
 }
 
@@ -304,7 +313,7 @@ func (r *LocalRunner) ContainerKiller(step Step) func() (int, error) {
 		r.stdout = step.Meta.Stdout
 		r.stderr = step.Meta.Stderr
 		// Get id(s) of container with name of step to kill
-		out, err := r.Output([]string{"ps", "-q", "--filter", "name=" + step.ContainerName()})
+		out, err := r.Output([]string{"ps", "-q", "--filter", fmt.Sprintf("name=%s$", step.ContainerName())})
 		if err != nil {
 			return counter, err
 		}
@@ -331,7 +340,7 @@ func (r *LocalRunner) ContainerRemover(step Step) func() error {
 		r.stdout = step.Meta.Stdout
 		r.stderr = step.Meta.Stderr
 		// Get id(s) of container with name of step to remove
-		out, err := r.Output([]string{"ps", "-a", "-q", "--filter", "name=" + step.ContainerName()})
+		out, err := r.Output([]string{"ps", "-a", "-q", "--filter", fmt.Sprintf("name=%s$", step.ContainerName())})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The problem with killing too many containers is/was:

https://docs.docker.com/engine/reference/commandline/ps/
> The `name` filter matches on all or part of a container’s name.