### PR TITLE
Add logs command

### DIFF
--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -1,0 +1,23 @@
+package cmd // import "github.com/ad-freiburg/gantry/cmd"
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(logsCmd)
+	logsCmd.Flags().BoolVar(&noFollow, "no-follow", false, "Do not follow log output.")
+}
+
+var (
+	noFollow bool
+)
+
+var logsCmd = &cobra.Command{
+	Use:   "logs [flags] [Service/Step...]",
+	Short: "View output from containers.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return pipeline.Logs(!noFollow)
+	},
+	PersistentPostRun: func(cmd *cobra.Command, args []string) {},
+}


### PR DESCRIPTION
This enables `gantry` to provide the `logs` command.

```
examples/docker-compose (git)-[logs] % gantry
2019/09/12 13:10:46 No environment file is used
2019/09/12 13:10:47 pipeline Execute:
2019/09/12 13:10:47 pipeline - Starting: docker-compose_db
2019/09/12 13:10:47 docker-compose_db c3b3f81a8c3b8ce064343a0936de57261ef69cead68004bdfe968af8e2ebc691
2019/09/12 13:10:48 pipeline - Finished docker-compose_db after 649.027203ms
2019/09/12 13:10:48 pipeline - Starting: docker-compose_wordpress
2019/09/12 13:10:48 docker-compose_wordpress e8e3fcb4636d02abbffd3065793a8d5f6212def352f3f822f94c90ab91a94352
2019/09/12 13:10:49 pipeline - Finished docker-compose_wordpress after 728.873348ms
2019/09/12 13:10:49 pipeline Executed 2 steps in 1.637316408s
2019/09/12 13:10:49 pipeline Total time spent inside steps: 1.377900551s

examples/docker-compose (git)-[logs] % gantry logs
2019/09/12 13:10:50 No environment file is used
2019/09/12 13:10:51 docker-compose_db 2019-09-12T11:10:48.543624Z 0 [Warning] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).
2019/09/12 13:10:51 docker-compose_db 2019-09-12T11:10:48.545082Z 0 [Note] mysqld (mysqld 5.7.27) starting as process 1 ...
2019/09/12 13:10:51 docker-compose_db 2019-09-12T11:10:48.549946Z 0 [Note] InnoDB: PUNCH HOLE support available
[...]
2019/09/12 13:10:51 docker-compose_wordpress WordPress not found in /var/www/html - copying now...
2019/09/12 13:10:51 docker-compose_wordpress Complete! WordPress has been successfully copied to /var/www/html
2019/09/12 13:10:51 docker-compose_wordpress AH00558: apache2: Could not reliably determine the server's fully qualified domain name, using 172.27.0.3. Set the 'ServerName' directive globally to suppress this message
[...]
```