### PR TITLE
Abort on prerun failure

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,6 +68,8 @@ var rootCmd = &cobra.Command{
 		}
 		gantry.ProjectName = strings.ReplaceAll(strings.ReplaceAll(strings.ToLower(gantry.ProjectName), " ", "_"), ".", "")
 		pipeline.Network = gantry.Network(fmt.Sprintf("%s_gantry", gantry.ProjectName))
+		// We have valid data, silence generic usage information now.
+		cmd.SilenceUsage = true
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
gantry now aborts running if any step fails to pull or build its image.