### PR TITLE
Add travis tests for multiple archs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: go
 arch:
   - amd64
   - arm64
+  - ppc64le
+  - s390x
 
 go:
   - "1.12.x"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: go
 
+arch:
+  - amd64
+  - arm64
+
 go:
   - "1.12.x"
   - "1.13.x"


### PR DESCRIPTION
As suggested with #50 this PR adds initial testing for `arm64` as only `amd64` and `arm64` are supported by `travis`. See: https://blog.travis-ci.com/2019-10-07-multi-cpu-architecture-support