### PR TITLE
Improve docker-compose compatibility of version check

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -287,24 +287,35 @@ func NewPipelineDefinition(path string, env *PipelineEnvironment) (*PipelineDefi
 	return d, nil
 }
 
+// https://docs.docker.com/compose/compose-file/compose-versioning/#versioning
 func (p *PipelineDefinition) checkVersion() error {
-	// docker-compose file format versions are MAJOR.MINOR only
-	parts := strings.SplitN(p.Version, ".", 2)
-	if len(parts) != 2 {
+	var err error
+	parts := strings.Split(p.Version, ".")
+	if len(parts) > 2 {
 		return fmt.Errorf("invalid compose file format version: %s", p.Version)
 	}
-	major, err := strconv.Atoi(parts[0])
-	if err != nil {
-		return err
+	// Version 1, the legacy format. This is specified by omitting a `version`
+	// key at the root of the YAML.
+	major := 1
+	if len(parts[0]) > 0 {
+		major, err = strconv.Atoi(parts[0])
+		if err != nil {
+			return fmt.Errorf("invalid compose file format version: %s", p.Version)
+		}
 	}
-	minor, err := strconv.Atoi(parts[1])
-	if err != nil {
-		return err
+	// If no minor version is given, 0 is used by default and not the latest
+	// minor version.
+	minor := 0
+	if len(parts) > 1 {
+		minor, err = strconv.Atoi(parts[1])
+		if err != nil {
+			return fmt.Errorf("invalid compose file format version: %s", p.Version)
+		}
 	}
 	if major < DockerComposeFileFormatMajorMin {
-		return fmt.Errorf("not supported compose file format version: got: %s want >= %d.%d", p.Version, DockerComposeFileFormatMajorMin, DockerComposeFileFormatMinorMin)
+		return fmt.Errorf("not supported compose file format version: got: %d.%d want >= %d.%d", major, minor, DockerComposeFileFormatMajorMin, DockerComposeFileFormatMinorMin)
 	} else if major == DockerComposeFileFormatMajorMin && minor < DockerComposeFileFormatMinorMin {
-		return fmt.Errorf("not supported compose file format version: got: %s want >= %d.%d", p.Version, DockerComposeFileFormatMajorMin, DockerComposeFileFormatMinorMin)
+		return fmt.Errorf("not supported compose file format version: got: %d.%d want >= %d.%d", major, minor, DockerComposeFileFormatMajorMin, DockerComposeFileFormatMinorMin)
 	}
 	return nil
 }

--- a/pipeline_internal_test.go
+++ b/pipeline_internal_test.go
@@ -628,7 +628,7 @@ func TestPipelineDefinitionCheckVersion(t *testing.T) {
 	}{
 		{
 			version: "",
-			err:     "invalid compose file format version: ",
+			err:     fmt.Sprintf("not supported compose file format version: got: 1.0 want >= %d.%d", DockerComposeFileFormatMajorMin, DockerComposeFileFormatMinorMin),
 		},
 		{
 			version: "foo",
@@ -636,14 +636,18 @@ func TestPipelineDefinitionCheckVersion(t *testing.T) {
 		},
 		{
 			version: "x.y",
-			err:     "strconv.Atoi: parsing \"x\": invalid syntax",
+			err:     "invalid compose file format version: x.y",
 		},
 		{
 			version: "0.y",
-			err:     "strconv.Atoi: parsing \"y\": invalid syntax",
+			err:     "invalid compose file format version: 0.y",
 		},
 		{
 			version: "1.0",
+			err:     fmt.Sprintf("not supported compose file format version: got: 1.0 want >= %d.%d", DockerComposeFileFormatMajorMin, DockerComposeFileFormatMinorMin),
+		},
+		{
+			version: "1",
 			err:     fmt.Sprintf("not supported compose file format version: got: 1.0 want >= %d.%d", DockerComposeFileFormatMajorMin, DockerComposeFileFormatMinorMin),
 		},
 		{
@@ -655,12 +659,20 @@ func TestPipelineDefinitionCheckVersion(t *testing.T) {
 			err:     "",
 		},
 		{
+			version: fmt.Sprintf("%d", DockerComposeFileFormatMajorMin+1),
+			err:     "",
+		},
+		{
 			version: fmt.Sprintf("%d.%d", DockerComposeFileFormatMajorMin+1, DockerComposeFileFormatMinorMin),
 			err:     "",
 		},
 		{
 			version: fmt.Sprintf("%d.%d", DockerComposeFileFormatMajorMin, DockerComposeFileFormatMinorMin+1),
 			err:     "",
+		},
+		{
+			version: fmt.Sprintf("%d.%d.1", DockerComposeFileFormatMajorMin, DockerComposeFileFormatMinorMin+1),
+			err:     fmt.Sprintf("invalid compose file format version: %d.%d.1", DockerComposeFileFormatMajorMin, DockerComposeFileFormatMinorMin+1),
 		},
 	}
 	for i, c := range cases {


### PR DESCRIPTION
This PR improves the compatibility of the version check as mentioned in https://github.com/ad-freiburg/gantry/pull/47#issuecomment-560111541