### PR TITLE
Modify preprocessor command to be more usefull

### DIFF
--- a/cmd/preprocessor.go
+++ b/cmd/preprocessor.go
@@ -3,7 +3,6 @@ package cmd // import "github.com/ad-freiburg/gantry/cmd"
 import (
 	"fmt"
 
-	"github.com/ad-freiburg/gantry/preprocessor"
 	"github.com/spf13/cobra"
 )
 
@@ -13,20 +12,12 @@ func init() {
 
 var preprocessorCmd = &cobra.Command{
 	Use:   "preprocessor",
-	Short: "",
+	Short: "Preprocessor functionality, has subcommands",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Println("Available preprocessor functions:")
-		p, err := preprocessor.NewPreprocessor()
-		if err != nil {
-			return err
-		}
-		for _, f := range p.Functions() {
-			fmt.Printf("\n%s\n", f.Usage())
-		}
-		return nil
+		return fmt.Errorf("missing sub-command")
 	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {},
 }

--- a/cmd/preprocessor_apply.go
+++ b/cmd/preprocessor_apply.go
@@ -1,0 +1,76 @@
+package cmd // import "github.com/ad-freiburg/gantry/cmd"
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"syscall"
+
+	"github.com/ad-freiburg/gantry"
+	"github.com/ad-freiburg/gantry/preprocessor"
+	"github.com/ad-freiburg/gantry/types"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	preprocessorCmd.AddCommand(preprocessorApplyCmd)
+}
+
+var preprocessorApplyCmd = &cobra.Command{
+	Use:   "apply file",
+	Short: "Prints the result of applying the preprocessor to the given file",
+	Args:  cobra.ExactArgs(1),
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var err error
+		defFile = args[0]
+		ignoredSteps := types.StringSet{}
+		for _, step := range stepsToIgnore {
+			ignoredSteps[step] = true
+		}
+		selectedSteps := types.StringSet{}
+		for _, step := range args {
+			selectedSteps[step] = true
+		}
+		env := types.StringMap{}
+		for _, v := range environment {
+			parts := strings.SplitN(v, "=", 2)
+			if len(parts) == 1 {
+				env[parts[0]] = nil
+			} else {
+				env[parts[0]] = &parts[1]
+			}
+		}
+		environment, err := gantry.NewPipelineEnvironment(envFile, env, ignoredSteps, selectedSteps)
+		if err != nil {
+			if e, ok := err.(*os.PathError); ok && e.Err != syscall.ENOENT {
+				return err
+			}
+		}
+
+		file, err := os.Open(defFile)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		data, err := ioutil.ReadAll(file)
+		if err != nil {
+			return err
+		}
+		// Apply environment to yaml
+		preproc, err := preprocessor.NewPreprocessor()
+		if err != nil {
+			return err
+		}
+		data, err = preproc.Process(data, environment)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%s\n", data)
+		return nil
+	},
+	PersistentPostRun: func(cmd *cobra.Command, args []string) {},
+}

--- a/cmd/preprocessor_apply.go
+++ b/cmd/preprocessor_apply.go
@@ -19,7 +19,7 @@ func init() {
 
 var preprocessorApplyCmd = &cobra.Command{
 	Use:   "apply file",
-	Short: "Prints the result of applying the preprocessor to the given file",
+	Short: "Prints the result of pre-processing the given file without executing or altering it",
 	Args:  cobra.ExactArgs(1),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		return nil
@@ -51,6 +51,7 @@ var preprocessorApplyCmd = &cobra.Command{
 			}
 		}
 
+		// Read file
 		file, err := os.Open(defFile)
 		if err != nil {
 			return err
@@ -60,8 +61,10 @@ var preprocessorApplyCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		// Apply environment to yaml
+
+		// Run preprocessor
 		preproc, err := preprocessor.NewPreprocessor()
+		preproc.DryRun = true
 		if err != nil {
 			return err
 		}
@@ -69,6 +72,8 @@ var preprocessorApplyCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
+		// Print result
 		fmt.Printf("%s\n", data)
 		return nil
 	},

--- a/cmd/preprocessor_statements.go
+++ b/cmd/preprocessor_statements.go
@@ -1,0 +1,32 @@
+package cmd // import "github.com/ad-freiburg/gantry/cmd"
+
+import (
+	"fmt"
+
+	"github.com/ad-freiburg/gantry/preprocessor"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	preprocessorCmd.AddCommand(preprocessorStatementsCmd)
+}
+
+var preprocessorStatementsCmd = &cobra.Command{
+	Use:   "statements",
+	Short: "",
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Println("Available preprocessor statements:")
+		p, err := preprocessor.NewPreprocessor()
+		if err != nil {
+			return err
+		}
+		for _, f := range p.Functions() {
+			fmt.Printf("\n%s\n", f.Usage())
+		}
+		return nil
+	},
+	PersistentPostRun: func(cmd *cobra.Command, args []string) {},
+}

--- a/environment.go
+++ b/environment.go
@@ -12,10 +12,6 @@ import (
 	"github.com/ghodss/yaml"
 )
 
-const undefinedArgumentFormat string = "argmuent '%s' not defined for '%s', no fallback provided"
-const missingArgumentFormat string = "missing argument(s) for '%s'. Need atleast %d argument"
-const tooManyArgumentsFormat string = "too many arguments for '%s'. Got %d want <= %d"
-
 type pipelineEnvironmentJSON struct {
 	Version            string          `json:"version"`
 	Substitutions      types.StringMap `json:"substitutions"`

--- a/preprocessor/function.go
+++ b/preprocessor/function.go
@@ -6,7 +6,7 @@ import (
 
 // Function is a function executable by the preprocessor
 type Function struct {
-	Func          func(Instruction, Environment) error
+	Func          func(Instruction, Environment, bool) error
 	Names         []string
 	Description   string
 	NumArgsMin    int
@@ -29,11 +29,11 @@ func (f Function) Check(i Instruction) error {
 }
 
 // Execute executes the function for the given instruction and environment
-func (f Function) Execute(i Instruction, e Environment) error {
+func (f Function) Execute(i Instruction, e Environment, dryRun bool) error {
 	if err := f.Check(i); err != nil {
 		return err
 	}
-	return f.Func(i, e)
+	return f.Func(i, e, dryRun)
 }
 
 // Usage returns this usage information of the function.

--- a/preprocessor/preprocessor_internal_test.go
+++ b/preprocessor/preprocessor_internal_test.go
@@ -210,6 +210,7 @@ func TestCheckIfDirExists(t *testing.T) {
 
 	cases := []struct {
 		instruction  Instruction
+		dryRun       bool
 		errorMessage string
 	}{
 		{
@@ -219,6 +220,7 @@ func TestCheckIfDirExists(t *testing.T) {
 				CurrentValue:      &iDoNotExist,
 				CurrentValueFound: true,
 			},
+			false,
 			"path error in FUNCTION for I_DO_NOT_EXIST: err: 'stat /iDoNotExist: no such file or directory'",
 		},
 		{
@@ -228,6 +230,7 @@ func TestCheckIfDirExists(t *testing.T) {
 				CurrentValue:      &notAPath,
 				CurrentValueFound: true,
 			},
+			false,
 			fmt.Sprintf("path error in FUNCTION for NOT_A_PATH: not a directory '%s'", notAPath),
 		},
 		{
@@ -237,6 +240,17 @@ func TestCheckIfDirExists(t *testing.T) {
 				CurrentValue:      &tempDir,
 				CurrentValueFound: true,
 			},
+			false,
+			"",
+		},
+		{
+			Instruction{
+				Function:          "FUNCTION",
+				Variable:          "I_DO_NOT_EXIST",
+				CurrentValue:      &iDoNotExist,
+				CurrentValueFound: true,
+			},
+			true,
 			"",
 		},
 	}
@@ -248,7 +262,7 @@ func TestCheckIfDirExists(t *testing.T) {
 			"I_DO_NOT_EXIST": &iDoNotExist,
 			"NOT_A_PATH":     &notAPath,
 		}
-		err := checkIfDirExists(c.instruction, env)
+		err := checkIfDirExists(c.instruction, env, c.dryRun)
 		if len(c.errorMessage) > 0 {
 			if err == nil {
 				t.Errorf("expected error @%d, got nil", i)
@@ -278,7 +292,7 @@ func TestSetIfEmpty(t *testing.T) {
 		Arguments:         []string{"foo"},
 		CurrentValue:      &tempDir,
 		CurrentValueFound: true,
-	}, env)
+	}, env, false)
 	if err != nil {
 		t.Errorf("unexpected error, got: %s", err)
 	}
@@ -296,7 +310,7 @@ func TestSetIfEmpty(t *testing.T) {
 		Arguments:         []string{"foo"},
 		CurrentValue:      nil,
 		CurrentValueFound: true,
-	}, &env)
+	}, &env, false)
 	if err != nil {
 		t.Errorf("unexpected error, got: %s", err)
 	}
@@ -320,7 +334,7 @@ func TestSetIfEmpty(t *testing.T) {
 		Variable:     "EMPTY",
 		Arguments:    []string{"foo"},
 		CurrentValue: &empty,
-	}, &env)
+	}, &env, false)
 	if err != nil {
 		t.Errorf("unexpected error, got: %s", err)
 	}
@@ -347,7 +361,7 @@ func TestSetIfEmpty(t *testing.T) {
 		Variable:     "UNDEFINED",
 		Arguments:    []string{"foo"},
 		CurrentValue: nil,
-	}, &env)
+	}, &env, false)
 	if err != nil {
 		t.Errorf("unexpected error, got: %s", err)
 	}
@@ -450,6 +464,7 @@ func TestTempDirIfEmpty(t *testing.T) {
 
 	cases := []struct {
 		instruction  Instruction
+		dryRun       bool
 		errorMessage string
 	}{
 		{
@@ -459,6 +474,7 @@ func TestTempDirIfEmpty(t *testing.T) {
 				CurrentValue:      &empty,
 				CurrentValueFound: true,
 			},
+			false,
 			"",
 		},
 		{
@@ -468,6 +484,7 @@ func TestTempDirIfEmpty(t *testing.T) {
 				CurrentValue:      &tempDir,
 				CurrentValueFound: true,
 			},
+			false,
 			"",
 		},
 		{
@@ -477,6 +494,7 @@ func TestTempDirIfEmpty(t *testing.T) {
 				CurrentValue:      nil,
 				CurrentValueFound: true,
 			},
+			false,
 			"",
 		},
 		{
@@ -486,6 +504,7 @@ func TestTempDirIfEmpty(t *testing.T) {
 				CurrentValue:      nil,
 				CurrentValueFound: false,
 			},
+			false,
 			"",
 		},
 		{
@@ -495,6 +514,7 @@ func TestTempDirIfEmpty(t *testing.T) {
 				CurrentValue:      &iDoNotExist,
 				CurrentValueFound: true,
 			},
+			false,
 			"path error in FUNCTION for I_DO_NOT_EXIST: err: 'stat /iDoNotExist: no such file or directory'",
 		},
 		{
@@ -504,7 +524,28 @@ func TestTempDirIfEmpty(t *testing.T) {
 				CurrentValue:      &notAPath,
 				CurrentValueFound: true,
 			},
+			false,
 			fmt.Sprintf("path error in FUNCTION for NOT_A_PATH: not a directory '%s'", notAPath),
+		},
+		{
+			Instruction{
+				Function:          "FUNCTION",
+				Variable:          "I_DO_NOT_EXIST",
+				CurrentValue:      &iDoNotExist,
+				CurrentValueFound: true,
+			},
+			true,
+			"",
+		},
+		{
+			Instruction{
+				Function:          "FUNCTION",
+				Variable:          "NOT_A_PATH",
+				CurrentValue:      &notAPath,
+				CurrentValueFound: true,
+			},
+			true,
+			"",
 		},
 	}
 	for i, c := range cases {
@@ -515,7 +556,7 @@ func TestTempDirIfEmpty(t *testing.T) {
 			"I_DO_NOT_EXIST": &iDoNotExist,
 			"NOT_A_PATH":     &notAPath,
 		}
-		err := tempDirIfEmpty(c.instruction, env)
+		err := tempDirIfEmpty(c.instruction, env, c.dryRun)
 		if len(c.errorMessage) > 0 {
 			if err == nil {
 				t.Errorf("expected error @%d, got nil", i)
@@ -538,7 +579,7 @@ func TestTempDirIfEmpty(t *testing.T) {
 			"NOT_A_PATH":     &notAPath,
 		}
 		c := cases[0]
-		err = tempDirIfEmpty(c.instruction, env)
+		err = tempDirIfEmpty(c.instruction, env, false)
 		if err == nil {
 			t.Error("expected error, got nil")
 		}


### PR DESCRIPTION
I'm not satisfied with the current (pre this PR) state of the preprocessor integration. This PR shall help improve this.

As a first step it allows the usage of the preprocessor on any given file to check what will happen without running the complete gantry pipeline. It restructures the `preprocessor` command to be the hub for the `apply` sub-command to run it on any file, and the `statements` sub-command which shall list all supported functionality.

The setup duplicates some code (PreRunE) as the preprocessor is instanciated inside `NewPipeline` as part of `NewPipelineDefinition`. I'd like to make this more composable and not directly hardwired so the preprocessor can be better used on its own.

