### PR TITLE
Generate .deb and .rpm

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,6 +33,22 @@ archives:
   files:
     - LICENSE
     - README.md
+nfpms:
+- name_template: '{{ .ProjectName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+  replacements:
+    386: i386
+    amd64: x86_64
+    s390x: s390x
+    7: 7l
+    6: 6l
+    arm64: aarch64
+  homepage:  https://github.com/ad-freiburg/gantry
+  description: Pipeline management tool using containers as its building blocks
+  maintainer: Axel Lehmann <lehmann@cs.uni-freiburg.de>
+  license: APACHE 2.0
+  formats:
+  - deb
+  - rpm
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
This PR adds the generation of `.deb` and `.rpm` packages. Maybe these can be published in some supported repositories to allow automatic upgrades.